### PR TITLE
Harden admin authentication flow

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,8 @@
+import time
+from urllib.parse import urljoin, urlparse
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
 from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required
+from app.utils import verify_admin_password
 
 login_manager = LoginManager()
 login_manager.login_view = 'auth.login'
@@ -8,6 +11,65 @@ login_manager.login_message_category = 'warning'
 
 bp = Blueprint('auth', __name__)
 
+_FAILED_LOGINS = {}
+_MAX_LOGIN_ATTEMPTS = 5
+_ATTEMPT_WINDOW_SECONDS = 300
+_LOCKOUT_SECONDS = 600
+
+
+def _get_client_ip():
+    return request.remote_addr or 'unknown'
+
+
+def _is_safe_url(target):
+    if not target:
+        return False
+    host_url = urlparse(request.host_url)
+    redirect_url = urlparse(urljoin(request.host_url, target))
+    return redirect_url.scheme in ('http', 'https') and host_url.netloc == redirect_url.netloc
+
+
+def _login_rate_limited():
+    client_ip = _get_client_ip()
+    data = _FAILED_LOGINS.get(client_ip)
+    if not data:
+        return False, None
+
+    now = time.time()
+    locked_until = data.get('locked_until')
+    if locked_until and now < locked_until:
+        return True, locked_until - now
+
+    if locked_until and now >= locked_until:
+        _FAILED_LOGINS.pop(client_ip, None)
+        return False, None
+
+    first_attempt = data.get('first_attempt', now)
+    if now - first_attempt > _ATTEMPT_WINDOW_SECONDS:
+        _FAILED_LOGINS.pop(client_ip, None)
+        return False, None
+
+    if data.get('count', 0) >= _MAX_LOGIN_ATTEMPTS:
+        _FAILED_LOGINS[client_ip]['locked_until'] = now + _LOCKOUT_SECONDS
+        return True, _LOCKOUT_SECONDS
+
+    return False, None
+
+
+def _record_failed_login():
+    client_ip = _get_client_ip()
+    now = time.time()
+    data = _FAILED_LOGINS.get(client_ip)
+    if not data:
+        _FAILED_LOGINS[client_ip] = {'count': 1, 'first_attempt': now}
+        return
+
+    if now - data.get('first_attempt', now) > _ATTEMPT_WINDOW_SECONDS:
+        _FAILED_LOGINS[client_ip] = {'count': 1, 'first_attempt': now}
+        return
+
+    data['count'] = data.get('count', 0) + 1
+    _FAILED_LOGINS[client_ip] = data
 
 class User(UserMixin):
     """Simple user class for single-admin authentication."""
@@ -24,7 +86,7 @@ class User(UserMixin):
         if not admin_password:
             return None
         
-        if username == admin_username and password == admin_password:
+        if username == admin_username and verify_admin_password(admin_password, password):
             return User(id=username)
         return None
 
@@ -41,6 +103,12 @@ def load_user(user_id):
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
+        limited, remaining = _login_rate_limited()
+        if limited:
+            minutes = max(1, int(remaining // 60))
+            flash(f'Too many failed attempts. Try again in {minutes} minute(s).', 'error')
+            return render_template('auth/login.html')
+
         username = request.form.get('username', '').strip()
         password = request.form.get('password', '')
         remember = request.form.get('remember') == 'on'
@@ -49,11 +117,13 @@ def login():
         
         if user:
             login_user(user, remember=remember)
+            _FAILED_LOGINS.pop(_get_client_ip(), None)
             next_page = request.args.get('next')
-            if next_page:
+            if next_page and _is_safe_url(next_page):
                 return redirect(next_page)
             return redirect(url_for('main.dashboard'))
         
+        _record_failed_login()
         flash('Invalid username or password.', 'error')
     
     return render_template('auth/login.html')

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from flask_login import login_required, current_user
 from app import db
 from app.models import CommunityMember, Event, EventRegistration, MessageLog, ScheduledMessage
-from app.utils import normalize_phone, validate_phone, parse_recipients_csv, parse_phones_csv
+from app.utils import normalize_phone, validate_phone, parse_recipients_csv, parse_phones_csv, verify_admin_password
 
 bp = Blueprint('main', __name__)
 
@@ -606,7 +606,7 @@ def logs_clear():
         flash('ADMIN_PASSWORD not configured in .env file.', 'error')
         return redirect(url_for('main.logs_list'))
     
-    if admin_password != expected_password:
+    if not verify_admin_password(expected_password, admin_password):
         flash('Invalid admin password.', 'error')
         return redirect(url_for('main.logs_list'))
     

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,8 @@
 import re
 import csv
 import io
+import hmac
+from werkzeug.security import check_password_hash
 
 
 def normalize_phone(phone: str) -> str:
@@ -148,3 +150,14 @@ def parse_phones_csv(file_content: str) -> list:
                     phones.append(normalized)
     
     return phones
+
+
+def verify_admin_password(stored_password: str, provided_password: str) -> bool:
+    """Verify admin password with support for hashed values."""
+    if not stored_password or not provided_password:
+        return False
+
+    if stored_password.startswith(('pbkdf2:', 'scrypt:', 'argon2:')):
+        return check_password_hash(stored_password, provided_password)
+
+    return hmac.compare_digest(stored_password, provided_password)


### PR DESCRIPTION
### Motivation
- Prevent open-redirects and brute-force attacks on the admin login endpoint by adding safe redirect checks and rate limiting. 
- Support secure admin password storage by accepting hashed passwords and avoiding timing attacks on plaintext comparisons. 
- Centralize password verification so other admin-protected actions use the same secure check. 

### Description
- Added `verify_admin_password(stored_password, provided_password)` in `app/utils.py` to support common password hash prefixes and to use `hmac.compare_digest` for plaintext comparisons. 
- Hardened the login flow in `app/auth.py` by adding an in-memory rate limiter (`_FAILED_LOGINS`), failed-attempt tracking, lockout windows, safe redirect validation via `_is_safe_url`, and clearing of failed counters on successful login. 
- Updated `app/routes.py` to reuse `verify_admin_password` when validating the admin password for the `logs_clear` action. 

### Testing
- Commands run during the change inspection and commit: `ls`, `sed -n '1,200p' app/config.py`, `sed -n '1,200p' app/auth.py`, `sed -n '1,260p' app/routes.py`, `sed -n '1,200p' app/services/twilio_service.py`, `sed -n '1,200p' app/utils.py`, `git status -sb`, `git add app/auth.py app/routes.py app/utils.py`, and `git commit -m "Harden admin authentication flow"`. 
- No automated test suite was executed as part of this change (no tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587f4d647c8324a708f1bcc4c7593b)