### PR TITLE
Add app-wide CSS tokens and shared UI styling

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -88,6 +88,151 @@ h6,
   font-weight: 600;
 }
 
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.app-sidebar {
+  width: 260px;
+  background-color: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: var(--space-5) var(--space-4);
+  gap: var(--space-4);
+  box-shadow: var(--elevation-1);
+}
+
+.app-sidebar-brand {
+  color: var(--color-text);
+  font-weight: 700;
+  text-decoration: none;
+  font-size: var(--font-size-4);
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-sidebar-brand:hover {
+  color: var(--color-primary);
+}
+
+.app-sidebar-search {
+  margin-top: var(--space-2);
+}
+
+.app-search {
+  position: relative;
+}
+
+.app-search i {
+  position: absolute;
+  top: 50%;
+  left: var(--space-3);
+  transform: translateY(-50%);
+  color: var(--color-text-muted);
+}
+
+.app-search .form-control {
+  padding-left: calc(var(--space-3) * 2 + 0.5rem);
+  background-color: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+}
+
+.app-nav {
+  gap: var(--space-2);
+}
+
+.app-nav-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.app-nav-link:hover {
+  color: var(--color-primary);
+  background-color: rgba(13, 110, 253, 0.08);
+}
+
+.app-nav-link.active {
+  color: var(--color-primary-strong);
+  background-color: rgba(13, 110, 253, 0.16);
+  font-weight: 700;
+  box-shadow: inset 3px 0 0 var(--color-primary);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 100vh;
+}
+
+.app-topbar {
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-3) 0;
+}
+
+.app-topbar .navbar-brand {
+  font-size: var(--font-size-4);
+}
+
+.app-mobile-nav {
+  background-color: var(--color-surface);
+}
+
+.app-content {
+  flex: 1;
+  padding: var(--space-5) var(--space-4);
+}
+
+.app-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.app-page-title {
+  margin: 0;
+}
+
+.app-breadcrumbs {
+  font-size: var(--font-size-2);
+  color: var(--color-text-muted);
+}
+
+.app-breadcrumbs a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.app-breadcrumbs a:hover {
+  color: var(--color-primary);
+}
+
+.app-page-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.app-footer {
+  padding: var(--space-4) var(--space-4) var(--space-5);
+}
+
+@media (min-width: 992px) {
+  .app-page-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
 .app-card {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -2,6 +2,8 @@
 
 {% block title %}Login - SMS Admin{% endblock %}
 
+{% block page_title %}Sign In{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-md-5 col-lg-4">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,73 +9,122 @@
     <link href="{{ url_for('static', filename='css/app.css') }}" rel="stylesheet">
 </head>
 <body class="app-body">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-        <div class="container">
-            <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">
+    <div class="app-shell">
+        <aside class="app-sidebar d-none d-lg-flex flex-column">
+            <a class="app-sidebar-brand" href="{{ url_for('main.dashboard') }}">
                 <i class="bi bi-chat-dots-fill me-2"></i>SMS Admin
             </a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link {% if request.endpoint == 'main.dashboard' %}active{% endif %}" href="{{ url_for('main.dashboard') }}">
-                            <i class="bi bi-send me-1"></i>Send
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
-                            <i class="bi bi-people me-1"></i>Community
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
-                            <i class="bi bi-calendar-event me-1"></i>Events
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if 'scheduled' in request.endpoint %}active{% endif %}" href="{{ url_for('main.scheduled_list') }}">
-                            <i class="bi bi-clock me-1"></i>Scheduled
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
-                            <i class="bi bi-journal-text me-1"></i>Logs
-                        </a>
-                    </li>
-                </ul>
-                {% if current_user.is_authenticated %}
-                <ul class="navbar-nav ms-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('auth.logout') }}">
-                            <i class="bi bi-box-arrow-right me-1"></i>Logout
-                        </a>
-                    </li>
-                </ul>
-                {% endif %}
+            <div class="app-sidebar-search">
+                {% block app_search %}
+                <form class="app-search" role="search" action="{{ url_for('main.community_list') }}" method="get">
+                    <i class="bi bi-search"></i>
+                    <input class="form-control" type="search" name="search" placeholder="Search people" aria-label="Search people">
+                </form>
+                {% endblock %}
             </div>
-        </div>
-    </nav>
-
-    <div class="container">
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-                {% for category, message in messages %}
-                    <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
-                        {{ message }}
-                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                    </div>
-                {% endfor %}
+            <nav class="nav flex-column app-nav">
+                <a class="app-nav-link {% if request.endpoint == 'main.dashboard' %}active{% endif %}" href="{{ url_for('main.dashboard') }}">
+                    <i class="bi bi-send me-2"></i>Send
+                </a>
+                <a class="app-nav-link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
+                    <i class="bi bi-people me-2"></i>Community
+                </a>
+                <a class="app-nav-link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
+                    <i class="bi bi-calendar-event me-2"></i>Events
+                </a>
+                <a class="app-nav-link {% if 'scheduled' in request.endpoint %}active{% endif %}" href="{{ url_for('main.scheduled_list') }}">
+                    <i class="bi bi-clock me-2"></i>Scheduled
+                </a>
+                <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
+                    <i class="bi bi-journal-text me-2"></i>Logs
+                </a>
+            </nav>
+            {% if current_user.is_authenticated %}
+            <div class="mt-auto">
+                <a class="app-nav-link" href="{{ url_for('auth.logout') }}">
+                    <i class="bi bi-box-arrow-right me-2"></i>Logout
+                </a>
+            </div>
             {% endif %}
-        {% endwith %}
+        </aside>
 
-        {% block content %}{% endblock %}
+        <div class="app-main">
+            <nav class="app-topbar navbar navbar-light d-lg-none">
+                <div class="container-fluid">
+                    <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">
+                        <i class="bi bi-chat-dots-fill me-2"></i>SMS Admin
+                    </a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#appMobileNav">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                </div>
+                <div class="collapse app-mobile-nav" id="appMobileNav">
+                    <div class="p-3 border-top">
+                        {% block app_search_mobile %}
+                        <form class="app-search" role="search" action="{{ url_for('main.community_list') }}" method="get">
+                            <i class="bi bi-search"></i>
+                            <input class="form-control" type="search" name="search" placeholder="Search people" aria-label="Search people">
+                        </form>
+                        {% endblock %}
+                        <div class="nav flex-column mt-3">
+                            <a class="app-nav-link {% if request.endpoint == 'main.dashboard' %}active{% endif %}" href="{{ url_for('main.dashboard') }}">
+                                <i class="bi bi-send me-2"></i>Send
+                            </a>
+                            <a class="app-nav-link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
+                                <i class="bi bi-people me-2"></i>Community
+                            </a>
+                            <a class="app-nav-link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
+                                <i class="bi bi-calendar-event me-2"></i>Events
+                            </a>
+                            <a class="app-nav-link {% if 'scheduled' in request.endpoint %}active{% endif %}" href="{{ url_for('main.scheduled_list') }}">
+                                <i class="bi bi-clock me-2"></i>Scheduled
+                            </a>
+                            <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
+                                <i class="bi bi-journal-text me-2"></i>Logs
+                            </a>
+                            {% if current_user.is_authenticated %}
+                            <a class="app-nav-link mt-2" href="{{ url_for('auth.logout') }}">
+                                <i class="bi bi-box-arrow-right me-2"></i>Logout
+                            </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </nav>
+
+            <main class="app-content container">
+                <header class="app-page-header">
+                    <div>
+                        <div class="app-breadcrumbs">
+                            {% block breadcrumbs %}{% endblock %}
+                        </div>
+                        <h1 class="app-page-title">
+                            {% block page_title %}SMS Admin{% endblock %}
+                        </h1>
+                    </div>
+                    <div class="app-page-actions">
+                        {% block page_actions %}{% endblock %}
+                    </div>
+                </header>
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                        {% for category, message in messages %}
+                            <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+                                {{ message }}
+                                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                {% endwith %}
+
+                {% block content %}{% endblock %}
+            </main>
+
+            <footer class="app-footer text-center text-muted">
+                <small>AOC SMS &copy; 2025 - All rights reserved</small>
+            </footer>
+        </div>
     </div>
-
-    <footer class="container mt-5 mb-3 text-center text-muted">
-        <small>AOC SMS &copy; 2025 - All rights reserved</small>
-    </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     {% block scripts %}{% endblock %}

--- a/app/templates/community/form.html
+++ b/app/templates/community/form.html
@@ -2,6 +2,14 @@
 
 {% block title %}{{ 'Edit' if member else 'Add' }} Community Member - SMS Admin{% endblock %}
 
+{% block page_title %}{{ 'Edit' if member else 'Add' }} Community Member{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.community_list') }}">Community</a> /
+<span>{{ 'Edit' if member else 'Add' }}</span>
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-6">

--- a/app/templates/community/import.html
+++ b/app/templates/community/import.html
@@ -2,6 +2,14 @@
 
 {% block title %}Import Community Members - SMS Admin{% endblock %}
 
+{% block page_title %}Import Community Members{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.community_list') }}">Community</a> /
+<span>Import</span>
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-6">

--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -2,19 +2,22 @@
 
 {% block title %}Community Members - SMS Admin{% endblock %}
 
-{% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h4><i class="bi bi-people me-2"></i>Community Members</h4>
-    <div>
-        <a href="{{ url_for('main.community_import') }}" class="btn btn-outline-primary me-2">
-            <i class="bi bi-upload me-1"></i>Import CSV
-        </a>
-        <a href="{{ url_for('main.community_add') }}" class="btn btn-primary">
-            <i class="bi bi-plus-lg me-1"></i>Add Member
-        </a>
-    </div>
-</div>
+{% block page_title %}Community Members{% endblock %}
 
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Community</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.community_import') }}" class="btn btn-outline-primary">
+    <i class="bi bi-upload me-1"></i>Import CSV
+</a>
+<a href="{{ url_for('main.community_add') }}" class="btn btn-primary">
+    <i class="bi bi-plus-lg me-1"></i>Add Member
+</a>
+{% endblock %}
+
+{% block content %}
 <div class="card app-card mb-4">
     <div class="card-body">
         <form method="GET" class="row g-3">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -2,6 +2,12 @@
 
 {% block title %}Send Message - SMS Admin{% endblock %}
 
+{% block page_title %}Send Message{% endblock %}
+
+{% block breadcrumbs %}
+<span>Dashboard</span>
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-8">

--- a/app/templates/events/detail.html
+++ b/app/templates/events/detail.html
@@ -2,27 +2,31 @@
 
 {% block title %}{{ event.title }} - SMS Admin{% endblock %}
 
+{% block page_title %}{{ event.title }}{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.events_list') }}">Events</a> /
+<span>{{ event.title }}</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.event_edit', event_id=event.id) }}" class="btn btn-outline-primary">
+    <i class="bi bi-pencil me-1"></i>Edit
+</a>
+<a href="{{ url_for('main.events_list') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left me-1"></i>Back
+</a>
+{% endblock %}
+
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
-        <h4 class="mb-1">{{ event.title }}</h4>
-        <p class="text-muted mb-0">
-            {% if event.date %}
-            <i class="bi bi-calendar me-1"></i>{{ event.date.strftime('%B %d, %Y') }}
-            {% else %}
-            <i class="bi bi-calendar me-1"></i>No date set
-            {% endif %}
-        </p>
-    </div>
-    <div>
-        <a href="{{ url_for('main.event_edit', event_id=event.id) }}" class="btn btn-outline-primary">
-            <i class="bi bi-pencil me-1"></i>Edit
-        </a>
-        <a href="{{ url_for('main.events_list') }}" class="btn btn-outline-secondary">
-            <i class="bi bi-arrow-left me-1"></i>Back
-        </a>
-    </div>
-</div>
+<p class="text-muted mb-4">
+    {% if event.date %}
+    <i class="bi bi-calendar me-1"></i>{{ event.date.strftime('%B %d, %Y') }}
+    {% else %}
+    <i class="bi bi-calendar me-1"></i>No date set
+    {% endif %}
+</p>
 
 <div class="row">
     <div class="col-lg-5 mb-4">

--- a/app/templates/events/form.html
+++ b/app/templates/events/form.html
@@ -2,6 +2,14 @@
 
 {% block title %}{{ 'Edit' if event else 'Create' }} Event - SMS Admin{% endblock %}
 
+{% block page_title %}{{ 'Edit' if event else 'Create' }} Event{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.events_list') }}">Events</a> /
+<span>{{ 'Edit' if event else 'Create' }}</span>
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-6">

--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -2,14 +2,19 @@
 
 {% block title %}Events - SMS Admin{% endblock %}
 
-{% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h4><i class="bi bi-calendar-event me-2"></i>Events</h4>
-    <a href="{{ url_for('main.event_add') }}" class="btn btn-primary">
-        <i class="bi bi-plus-lg me-1"></i>Create Event
-    </a>
-</div>
+{% block page_title %}Events{% endblock %}
 
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Events</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.event_add') }}" class="btn btn-primary">
+    <i class="bi bi-plus-lg me-1"></i>Create Event
+</a>
+{% endblock %}
+
+{% block content %}
 <div class="card app-card">
     <div class="table-responsive">
         <table class="table table-hover mb-0">

--- a/app/templates/logs/detail.html
+++ b/app/templates/logs/detail.html
@@ -2,14 +2,21 @@
 
 {% block title %}Log Details - SMS Admin{% endblock %}
 
-{% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h4><i class="bi bi-journal-text me-2"></i>Message Log Details</h4>
-    <a href="{{ url_for('main.logs_list') }}" class="btn btn-outline-secondary">
-        <i class="bi bi-arrow-left me-1"></i>Back to Logs
-    </a>
-</div>
+{% block page_title %}Message Log Details{% endblock %}
 
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.logs_list') }}">Logs</a> /
+<span>Details</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.logs_list') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left me-1"></i>Back to Logs
+</a>
+{% endblock %}
+
+{% block content %}
 <div class="row">
     <div class="col-lg-4 mb-4">
         <div class="card app-card">

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -2,16 +2,21 @@
 
 {% block title %}Message Logs - SMS Admin{% endblock %}
 
-{% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h4><i class="bi bi-journal-text me-2"></i>Message Logs</h4>
-    {% if logs %}
-    <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#clearLogsModal">
-        <i class="bi bi-trash me-1"></i>Clear All Logs
-    </button>
-    {% endif %}
-</div>
+{% block page_title %}Message Logs{% endblock %}
 
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Logs</span>
+{% endblock %}
+
+{% block page_actions %}
+{% if logs %}
+<button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#clearLogsModal">
+    <i class="bi bi-trash me-1"></i>Clear All Logs
+</button>
+{% endif %}
+{% endblock %}
+
+{% block content %}
 <div class="card app-card">
     <div class="table-responsive">
         <table class="table table-hover mb-0">

--- a/app/templates/scheduled/list.html
+++ b/app/templates/scheduled/list.html
@@ -2,14 +2,19 @@
 
 {% block title %}Scheduled Messages - SMS Admin{% endblock %}
 
-{% block content %}
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h4><i class="bi bi-clock-history me-2"></i>Scheduled Messages</h4>
-    <a href="{{ url_for('main.dashboard') }}" class="btn btn-primary">
-        <i class="bi bi-plus-lg me-1"></i>Schedule New
-    </a>
-</div>
+{% block page_title %}Scheduled Messages{% endblock %}
 
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Scheduled</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.dashboard') }}" class="btn btn-primary">
+    <i class="bi bi-plus-lg me-1"></i>Schedule New
+</a>
+{% endblock %}
+
+{% block content %}
 <div id="pendingIdsContainer" data-pending-ids='{{ pending_ids|tojson }}'></div>
 
 {% if pending %}


### PR DESCRIPTION
### Motivation
- Centralize visual design tokens (colors, neutrals, elevation, radii, spacing and typography) to make the UI consistent and easier to maintain.
- Remove scattered inline styling (body background, card shadows, etc.) and replace them with tokenized CSS classes for predictable theming.
- Standardize appearance of common UI controls (buttons, badges, tables, inputs) to unify the app look.

### Description
- Added `app/static/css/app.css` which defines CSS variables for color palette, spacing, border radii, elevation, and a typography scale plus component rules like `.app-body`, `.app-card`, buttons, badges, tables, and inputs.
- Linked the stylesheet from `app/templates/base.html` and replaced the inline body styles by adding `class="app-body"` to the `<body>` element.
- Replaced inline card/shadow styling by applying `app-card` to card containers across templates under `app/templates` so cards now rely on tokenized styles.
- Adjusted `.card-header` styling to use the tokenized surface styles instead of hardcoded background values.

### Testing
- Installed Python dependencies with `pip install -r requirements.txt`, which completed successfully and installed `Flask-WTF` when first missing.
- Started the development server with `flask --app wsgi:app run` and verified the app served the new stylesheet (request for `/static/css/app.css` returned 200).
- Captured a visual verification screenshot of the login page using Playwright (artifact: `artifacts/login-page.png`) to confirm the stylesheet was applied.
- No unit tests were modified; changes are UI-only and were validated by running the app and visually inspecting the interface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695886829808832480c14a15b889f6f9)