### PR TITLE
Remove argon2 prefix from admin password verification

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -157,7 +157,7 @@ def verify_admin_password(stored_password: str, provided_password: str) -> bool:
     if not stored_password or not provided_password:
         return False
 
-    if stored_password.startswith(('pbkdf2:', 'scrypt:', 'argon2:')):
+    if stored_password.startswith(('pbkdf2:', 'scrypt:')):
         return check_password_hash(stored_password, provided_password)
 
     return hmac.compare_digest(stored_password, provided_password)


### PR DESCRIPTION
### Motivation
- Avoid raising a `ValueError` from `check_password_hash` when an `argon2:`-prefixed password is stored since Werkzeug only implements `pbkdf2` and `scrypt` internally.
- A stored `argon2:` hash would cause login and log-clear flows to 500 instead of returning an "invalid password" response.
- This change eliminates the regression by not attempting to verify unsupported hash schemes. 
- Keep behavior minimal and dependency-free by falling back to a constant-time comparison for unsupported formats.

### Description
- Update `verify_admin_password` in `app/utils.py` to remove the `'argon2:'` prefix from the tuple of recognized hashed-password prefixes. 
- Only `pbkdf2:` and `scrypt:` are now passed to `check_password_hash`, and all other values use `hmac.compare_digest`.
- The change is a single-line, scoped edit and introduces no new dependencies.

### Testing
- Commands run during the change: `ls`, `sed -n '1,200p' app/utils.py`, `git status --short`, `git add app/utils.py`, and `git commit -m "Drop argon2 prefix from admin password check"`.
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695890ecf76c83248ed32da6a770fb5b)