### PR TITLE
Fix mobile layout scaling for content area

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -169,6 +169,7 @@ h6,
   flex-direction: column;
   flex: 1;
   min-height: 100vh;
+  min-width: 0;
 }
 
 .app-topbar {
@@ -188,6 +189,7 @@ h6,
 .app-content {
   flex: 1;
   padding: var(--space-5) var(--space-4);
+  min-width: 0;
 }
 
 .app-page-header {
@@ -252,6 +254,10 @@ h6,
 .table {
   color: var(--color-text);
   font-size: var(--font-size-2);
+}
+
+.table-responsive {
+  max-width: 100%;
 }
 
 .table th {


### PR DESCRIPTION
### Motivation
- Mobile pages were occasionally overscaled on small viewports (notably iOS) because flex children can force widths larger than the viewport and responsive tables can expand past the screen. 
- The goal is a minimal, deterministic CSS fix to prevent layout-driven auto-zoom/overscaling without changing markup or introducing dependencies. 
- Keep changes small and reviewable while preserving existing layout on desktop.

### Description
- Allow the main flex content to shrink by adding `min-width: 0` to `.app-main` and `.app-content` in `app/static/css/app.css` to prevent child overflow from forcing a larger layout.  
- Constrain responsive tables by adding `.table-responsive { max-width: 100%; }` so wide tables do not exceed the viewport width.  
- This is a CSS-only, UI-scoped change with no template or backend modifications.

### Testing
- Installed dependencies with `./venv/bin/pip install -r requirements.txt`, which completed successfully.  
- Started the development server with `ADMIN_PASSWORD=admin SECRET_KEY=dev-secret FLASK_ENV=development ./venv/bin/flask --app wsgi:app run --host 0.0.0.0 --port 5000`, which started and served pages.  
- Ran an automated Playwright script to load the app in a mobile viewport and capture `artifacts/community-mobile.png`, and the script produced the screenshot successfully.  
- No unit tests were modified or required for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958937ed45c8324b7b68a96a188978f)