### PR TITLE
Fix community table overflow on mobile

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -258,6 +258,8 @@ h6,
 
 .table-responsive {
   max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .table th {


### PR DESCRIPTION
### Motivation
- The Community page table was causing the page to expand past the viewport on small screens, producing horizontal overflow and layout issues.
- The intent is to keep the table responsive and allow horizontal scrolling inside the card instead of expanding the whole page.

### Description
- Add horizontal overflow handling to the responsive table wrapper in `app/static/css/app.css` by setting `overflow-x: auto` and `-webkit-overflow-scrolling: touch` on the `.table-responsive` rule.
- This change scopes scrolling to the table container so other pages and components are unaffected.

### Testing
- Started the development server with `export FLASK_ENV=development ADMIN_PASSWORD=admin SECRET_KEY=devsecret && flask --app wsgi:app run --debug` and the server launched successfully.
- Ran an automated Playwright script to log in and navigate to `/community`, capturing a screenshot of the page, which completed successfully and shows the table scrolling inside the card.
- No unit tests were changed or added for this visual/CSS-only fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695895660fb883249059e917dcf30e30)