### PR TITLE
Fix mobile overflow in community bulk actions header

### DIFF
--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -42,7 +42,7 @@
             <button type="button" class="btn btn-outline-secondary" id="selectNoneBtn">Select none</button>
             <button type="button" class="btn btn-outline-secondary" id="invertSelectionBtn">Invert</button>
         </div>
-        <div class="d-flex align-items-center">
+        <div class="d-flex flex-wrap align-items-center gap-2">
             <span class="text-muted me-3"><span id="selectedCount">0</span> selected</span>
             <button type="button" class="btn btn-sm btn-danger" id="bulkDeleteBtn" disabled
                     data-bs-toggle="modal" data-bs-target="#bulkDeleteModal">


### PR DESCRIPTION
### Motivation
- The community list page was slightly overflowing on small/mobile viewports when there were table entries while the empty state displayed correctly. 
- The bulk action controls in the card header needed to wrap instead of forcing a single-line layout that caused horizontal overflow.

### Description
- Updated the card header bulk actions container in `app/templates/community/list.html` to allow wrapping by adding `flex-wrap` and a small `gap` to the control wrapper. 
- This is a minimal, one-line template change that preserves existing buttons and behavior while fixing the layout on narrow screens.

### Testing
- Started the development server with `FLASK_ENV=development ADMIN_PASSWORD=admin SECRET_KEY=dev flask --app wsgi:app run --debug --host 0.0.0.0 --port 5000` and it launched successfully. 
- Ran a Playwright script that added two community members and navigated to `/community` at a mobile viewport, and it produced a screenshot (`artifacts/community-mobile.png`) showing the header wrapping correctly. 
- No unit tests were added or modified for this purely layout change. 
- The manual/visual check via the automated Playwright run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958990321e08324bf7cf52b860ec38c)