### PR TITLE
Add dashboard overview KPIs and recent activity

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -10,141 +10,252 @@
 
 {% block content %}
 <div class="row justify-content-center">
-    <div class="col-lg-8">
-        <div class="card app-card">
-            <div class="card-header">
-                <h5 class="mb-0"><i class="bi bi-send me-2"></i>Send SMS Blast</h5>
+    <div class="col-xl-10">
+        <section class="mb-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0"><i class="bi bi-speedometer2 me-2"></i>Overview</h5>
+                <small class="text-muted">Live system snapshot</small>
             </div>
-            <div class="card-body">
-                <form method="POST" id="sendForm">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="client_timezone" id="client_timezone">
-                    <div class="mb-3">
-                        <label for="message_body" class="form-label">Message</label>
-                        <textarea class="form-control" id="message_body" name="message_body" rows="4" 
-                                  placeholder="Enter your message..." required maxlength="1600"></textarea>
-                        <div class="form-text">
-                            <span id="charCount">0</span> / 1600 characters
-                        </div>
-                    </div>
-
-                    <div class="mb-3">
-                        <label class="form-label">Target Audience</label>
-                        <div class="form-check">
-                            <input class="form-check-input" type="radio" name="target" id="targetCommunity" 
-                                   value="community" checked>
-                            <label class="form-check-label" for="targetCommunity">
-                                <i class="bi bi-people me-1"></i>Community Blast
-                                <span class="text-muted">(all community recipients)</span>
-                            </label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="radio" name="target" id="targetEvent" 
-                                   value="event">
-                            <label class="form-check-label" for="targetEvent">
-                                <i class="bi bi-calendar-event me-1"></i>Event Blast
-                                <span class="text-muted">(registered event attendees)</span>
-                            </label>
-                        </div>
-                    </div>
-
-                    <div class="mb-3" id="eventSelectWrapper" style="display: none;">
-                        <label for="event_id" class="form-label">Select Event</label>
-                        <select class="form-select" id="event_id" name="event_id">
-                            <option value="">-- Select an event --</option>
-                            {% for event in events %}
-                            <option value="{{ event.id }}">
-                                {{ event.title }}{% if event.date %} ({{ event.date.strftime('%Y-%m-%d') }}){% endif %}
-                            </option>
-                            {% endfor %}
-                        </select>
-                    </div>
-
-                    <div class="mb-3">
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="include_unsubscribe" id="includeUnsubscribe" checked>
-                            <label class="form-check-label" for="includeUnsubscribe">
-                                <i class="bi bi-shield-check me-1"></i><strong>Include unsubscribe option</strong>
-                                <span class="text-muted">- Appends "Reply STOP to unsubscribe"</span>
-                            </label>
-                        </div>
-                    </div>
-
-                    <div class="mb-3">
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="schedule_later" id="scheduleLater">
-                            <label class="form-check-label" for="scheduleLater">
-                                <i class="bi bi-clock me-1"></i><strong>Schedule for later</strong>
-                            </label>
-                        </div>
-                    </div>
-
-                    <div class="mb-3" id="scheduleWrapper" style="display: none;">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <label for="schedule_date" class="form-label">Date</label>
-                                <input type="date" class="form-control" id="schedule_date" name="schedule_date">
-                            </div>
-                            <div class="col-md-6">
-                                <label for="schedule_time" class="form-label">Time</label>
-                                <input type="time" class="form-control" id="schedule_time" name="schedule_time">
+            <div class="row g-3">
+                <div class="col-md-6 col-xl-3">
+                    <div class="card app-card h-100">
+                        <div class="card-body">
+                            <div class="text-muted text-uppercase small">Total recipients</div>
+                            <div class="fs-4 fw-semibold">{{ total_recipients }}</div>
+                            <div class="text-muted small">
+                                Community {{ community_count }} • Event regs {{ event_registration_count }}
                             </div>
                         </div>
-                        <div class="form-text">
-                            <i class="bi bi-info-circle me-1"></i>Enter your local time. The scheduler checks every minute.
+                    </div>
+                </div>
+                <div class="col-md-6 col-xl-3">
+                    <div class="card app-card h-100">
+                        <div class="card-body">
+                            <div class="text-muted text-uppercase small">Last blast status</div>
+                            {% if latest_log %}
+                            <div class="fs-4 fw-semibold">
+                                {% if latest_log.failure_count == 0 %}Delivered{% else %}Partial{% endif %}
+                            </div>
+                            <div class="text-muted small">
+                                {{ latest_log.created_at.strftime('%Y-%m-%d %H:%M UTC') }}
+                            </div>
+                            <div class="text-muted small">
+                                {{ latest_log.success_count }}/{{ latest_log.total_recipients }} delivered
+                            </div>
+                            {% else %}
+                            <div class="fs-4 fw-semibold">No blasts yet</div>
+                            <div class="text-muted small">Send your first message to populate KPIs.</div>
+                            {% endif %}
                         </div>
                     </div>
-
-                    {% if admin_test_phone %}
-                    <div class="mb-3">
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="test_mode" id="testMode">
-                            <label class="form-check-label" for="testMode">
-                                <i class="bi bi-bug me-1"></i><strong>Test Mode</strong> - Send only to my phone ({{ admin_test_phone }})
-                            </label>
+                </div>
+                <div class="col-md-6 col-xl-3">
+                    <div class="card app-card h-100">
+                        <div class="card-body">
+                            <div class="text-muted text-uppercase small">Delivery rate</div>
+                            {% if success_rate is not none %}
+                            <div class="fs-4 fw-semibold">{{ success_rate }}%</div>
+                            <div class="text-muted small">Failures {{ failure_rate }}%</div>
+                            {% else %}
+                            <div class="fs-4 fw-semibold">N/A</div>
+                            <div class="text-muted small">No delivery data yet.</div>
+                            {% endif %}
                         </div>
-                        <div class="form-text text-warning">
-                            <i class="bi bi-exclamation-triangle me-1"></i>Uncheck to send to all recipients
+                    </div>
+                </div>
+                <div class="col-md-6 col-xl-3">
+                    <div class="card app-card h-100">
+                        <div class="card-body">
+                            <div class="text-muted text-uppercase small">Scheduled queue</div>
+                            <div class="fs-4 fw-semibold">{{ pending_scheduled_count }}</div>
+                            <div class="text-muted small">
+                                <a href="{{ url_for('main.scheduled_list') }}" class="text-decoration-none">View scheduled sends</a>
+                            </div>
                         </div>
-                    </div>
-                    {% endif %}
-
-                    <div class="d-grid gap-2">
-                        <button type="submit" class="btn btn-primary btn-lg" id="sendBtn">
-                            <i class="bi bi-send-fill me-2"></i>Send Now
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-
-        <div class="card app-card mt-4">
-            <div class="card-header">
-                <h6 class="mb-0"><i class="bi bi-info-circle me-2"></i>Quick Links</h6>
-            </div>
-            <div class="card-body">
-                <div class="row text-center">
-                    <div class="col-4">
-                        <a href="{{ url_for('main.community_list') }}" class="text-decoration-none">
-                            <i class="bi bi-people fs-4 d-block mb-1"></i>
-                            <small class="text-muted">Community</small>
-                        </a>
-                    </div>
-                    <div class="col-4">
-                        <a href="{{ url_for('main.events_list') }}" class="text-decoration-none">
-                            <i class="bi bi-calendar-event fs-4 d-block mb-1"></i>
-                            <small class="text-muted">Events ({{ events|length }})</small>
-                        </a>
-                    </div>
-                    <div class="col-4">
-                        <a href="{{ url_for('main.logs_list') }}" class="text-decoration-none">
-                            <i class="bi bi-journal-text fs-4 d-block mb-1"></i>
-                            <small class="text-muted">Logs</small>
-                        </a>
                     </div>
                 </div>
             </div>
-        </div>
+
+            <div class="card app-card mt-4">
+                <div class="card-header">
+                    <h6 class="mb-0"><i class="bi bi-info-circle me-2"></i>Quick Links</h6>
+                </div>
+                <div class="card-body">
+                    <div class="row text-center">
+                        <div class="col-4">
+                            <a href="{{ url_for('main.community_list') }}" class="text-decoration-none">
+                                <i class="bi bi-people fs-4 d-block mb-1"></i>
+                                <small class="text-muted">Community</small>
+                            </a>
+                        </div>
+                        <div class="col-4">
+                            <a href="{{ url_for('main.events_list') }}" class="text-decoration-none">
+                                <i class="bi bi-calendar-event fs-4 d-block mb-1"></i>
+                                <small class="text-muted">Events ({{ events|length }})</small>
+                            </a>
+                        </div>
+                        <div class="col-4">
+                            <a href="{{ url_for('main.logs_list') }}" class="text-decoration-none">
+                                <i class="bi bi-journal-text fs-4 d-block mb-1"></i>
+                                <small class="text-muted">Logs</small>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="mb-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0"><i class="bi bi-send me-2"></i>Send SMS Blast</h5>
+                <small class="text-muted">Action center</small>
+            </div>
+            <div class="card app-card">
+                <div class="card-body">
+                    <form method="POST" id="sendForm">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="client_timezone" id="client_timezone">
+                        <div class="mb-3">
+                            <label for="message_body" class="form-label">Message</label>
+                            <textarea class="form-control" id="message_body" name="message_body" rows="4"
+                                      placeholder="Enter your message..." required maxlength="1600"></textarea>
+                            <div class="form-text">
+                                <span id="charCount">0</span> / 1600 characters
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label">Target Audience</label>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="target" id="targetCommunity"
+                                       value="community" checked>
+                                <label class="form-check-label" for="targetCommunity">
+                                    <i class="bi bi-people me-1"></i>Community Blast
+                                    <span class="text-muted">(all community recipients)</span>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="target" id="targetEvent"
+                                       value="event">
+                                <label class="form-check-label" for="targetEvent">
+                                    <i class="bi bi-calendar-event me-1"></i>Event Blast
+                                    <span class="text-muted">(registered event attendees)</span>
+                                </label>
+                            </div>
+                            <div class="form-text">
+                                Choose Community to reach your master list, or Event to target a single registration list.
+                            </div>
+                        </div>
+
+                        <div class="mb-3" id="eventSelectWrapper" style="display: none;">
+                            <label for="event_id" class="form-label">Select Event</label>
+                            <select class="form-select" id="event_id" name="event_id">
+                                <option value="">-- Select an event --</option>
+                                {% for event in events %}
+                                <option value="{{ event.id }}">
+                                    {{ event.title }}{% if event.date %} ({{ event.date.strftime('%Y-%m-%d') }}){% endif %}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+
+                        <div class="mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="include_unsubscribe" id="includeUnsubscribe" checked>
+                                <label class="form-check-label" for="includeUnsubscribe">
+                                    <i class="bi bi-shield-check me-1"></i><strong>Include unsubscribe option</strong>
+                                    <span class="text-muted">- Appends "Reply STOP to unsubscribe"</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="schedule_later" id="scheduleLater">
+                                <label class="form-check-label" for="scheduleLater">
+                                    <i class="bi bi-clock me-1"></i><strong>Schedule for later</strong>
+                                </label>
+                            </div>
+                            <div class="form-text">
+                                Schedule sends in your local time ({{ app_timezone }} fallback). Leave unchecked to send immediately.
+                            </div>
+                        </div>
+
+                        <div class="mb-3" id="scheduleWrapper" style="display: none;">
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <label for="schedule_date" class="form-label">Date</label>
+                                    <input type="date" class="form-control" id="schedule_date" name="schedule_date">
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="schedule_time" class="form-label">Time</label>
+                                    <input type="time" class="form-control" id="schedule_time" name="schedule_time">
+                                </div>
+                            </div>
+                            <div class="form-text">
+                                <i class="bi bi-info-circle me-1"></i>Enter your local time. The scheduler checks every minute.
+                            </div>
+                        </div>
+
+                        {% if admin_test_phone %}
+                        <div class="mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="test_mode" id="testMode">
+                                <label class="form-check-label" for="testMode">
+                                    <i class="bi bi-bug me-1"></i><strong>Test Mode</strong> - Send only to my phone ({{ admin_test_phone }})
+                                </label>
+                            </div>
+                            <div class="form-text text-warning">
+                                <i class="bi bi-exclamation-triangle me-1"></i>Uncheck to send to all recipients
+                            </div>
+                        </div>
+                        {% endif %}
+
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary btn-lg" id="sendBtn">
+                                <i class="bi bi-send-fill me-2"></i>Send Now
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </section>
+
+        <section class="mb-4">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="mb-0"><i class="bi bi-activity me-2"></i>Recent Activity</h5>
+                <a href="{{ url_for('main.logs_list') }}" class="text-decoration-none small">View all logs</a>
+            </div>
+            <div class="card app-card">
+                <div class="card-body p-0">
+                    <ul class="list-group list-group-flush">
+                        {% for log in recent_logs %}
+                        <li class="list-group-item d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-2">
+                            <div>
+                                <div class="fw-semibold">{{ log.message_body|truncate(80) }}</div>
+                                <small class="text-muted">
+                                    {{ log.created_at.strftime('%Y-%m-%d %H:%M UTC') }}
+                                    • {{ log.target|capitalize }}
+                                    {% if log.event %}• {{ log.event.title }}{% endif %}
+                                </small>
+                            </div>
+                            <div class="text-md-end">
+                                <span class="badge bg-success">{{ log.success_count }} sent</span>
+                                {% if log.failure_count %}
+                                <span class="badge bg-danger">{{ log.failure_count }} failed</span>
+                                {% endif %}
+                                <div class="mt-2">
+                                    <a href="{{ url_for('main.log_detail', log_id=log.id) }}" class="btn btn-sm btn-outline-secondary">View</a>
+                                </div>
+                            </div>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item text-muted">No message activity yet. Send a blast to get started.</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </section>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide a strategic overview on the dashboard so admins can see system health and recent activity at a glance. 
- Surface operational KPIs such as total recipients, last blast delivery, and scheduled queue to aid quick decision making. 
- Move from a single-action form layout to a sectioned layout: overview → action form → recent activity. 

### Description
- Add `build_dashboard_context()` and `render_dashboard()` in `app/routes.py` to compute and pass metrics including `community_count`, `event_registration_count`, `total_recipients`, `latest_log`, `recent_logs`, `pending_scheduled_count`, `success_rate`, and `failure_rate` to the template. 
- Replace the prior form-centric layout in `app/templates/dashboard.html` with a three-section layout that includes KPI cards (total recipients, last blast status, delivery rate, scheduled queue), the send form with added contextual helper text for target selection and scheduling, and a "Recent Activity" list showing the last five `MessageLog` entries. 
- Keep existing send/schedule logic unchanged but centralize rendering via the new `render_dashboard()` helper to ensure the new context is always provided on validation errors. 

### Testing
- Started the development server with `FLASK_ENV=development ADMIN_PASSWORD=admin SECRET_KEY=dev flask --app wsgi:app run --host 0.0.0.0 --port 5000` and observed the app serve requests successfully (dashboard returned HTTP 200). 
- Ran an automated Playwright script to log in and capture a full-page screenshot which produced `artifacts/dashboard.png`, confirming the new layout renders without server errors. 
- No unit tests were added or run as part of this change. 
- Manual checks via the running dev server did not surface runtime template errors during the interactions exercised by the script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f42fb69c8324a885e11b510d0f5a)