### PR TITLE
Fix mobile hamburger menu alignment and styling

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -176,6 +176,8 @@ h6,
   background-color: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
   padding: var(--space-3) 0;
+  position: relative;
+  z-index: 1020;
 }
 
 .app-topbar .navbar-brand {
@@ -184,6 +186,20 @@ h6,
 
 .app-mobile-nav {
   background-color: var(--color-surface);
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  padding: 0 var(--space-3) var(--space-3);
+}
+
+.app-mobile-nav-panel {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--elevation-2);
+  max-width: 360px;
+  margin-left: auto;
 }
 
 .app-content {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -59,7 +59,7 @@
                     </button>
                 </div>
                 <div class="collapse app-mobile-nav" id="appMobileNav">
-                    <div class="p-3 border-top">
+                    <div class="app-mobile-nav-panel p-3 border-top">
                         {% block app_search_mobile %}
                         <form class="app-search" role="search" action="{{ url_for('main.community_list') }}" method="get">
                             <i class="bi bi-search"></i>


### PR DESCRIPTION
### Motivation
- The expanded mobile hamburger menu was left-aligned and visually awkward on small viewports.  
- The goal is a cleaner dropdown-style panel anchored to the top bar that looks consistent on mobile.  
- Make a minimal, reviewable change limited to the mobile nav HTML and CSS to preserve existing behavior elsewhere.  

### Description
- Add a wrapper element `app-mobile-nav-panel` around the collapsed mobile nav contents in `app/templates/base.html`.  
- Make the topbar positioned with a higher stacking context by setting `position: relative` and `z-index: 1020` in `app/static/css/app.css`.  
- Change `.app-mobile-nav` to be `position: absolute` and span the full width below the topbar with adjusted padding.  
- Add `.app-mobile-nav-panel` styling with background, border, rounded corners, shadow, `max-width: 360px`, and `margin-left: auto` to right-align the dropdown panel.  

### Testing
- Launched the development server with `flask --app wsgi:app run --debug --host 0.0.0.0 --port 5000` and it started successfully.  
- Ran a Playwright script that opened a 375x812 viewport and clicked the hamburger (`button.navbar-toggler`) to capture the mobile menu, producing `artifacts/mobile-nav.png`, confirming the panel appearance.  
- No unit tests were added because this is a visual/UI-only change.  
- All automated steps above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f63137f08324be7f9dae26c4a00f)