### PR TITLE
Allow community action buttons to wrap on small screens to prevent overflow

### DIFF
--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -79,20 +79,22 @@
                         <td>{{ member.name or '-' }}</td>
                         <td><code>{{ member.phone }}</code></td>
                         <td>{{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</td>
-                        <td class="text-nowrap">
-                            <a href="{{ url_for('main.community_edit', member_id=member.id) }}" 
-                               class="btn btn-sm btn-outline-secondary me-1" title="Edit">
-                                <i class="bi bi-pencil"></i>
-                            </a>
-                            <button type="button" class="btn btn-sm btn-outline-danger" title="Delete"
-                                    data-bs-toggle="modal" data-bs-target="#deleteModal" 
-                                    data-member-name="{{ member.name }}" data-form-id="delete-member-{{ member.id }}">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                            <form id="delete-member-{{ member.id }}" method="POST" 
-                                  action="{{ url_for('main.community_delete', member_id=member.id) }}" style="display:none;">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            </form>
+                        <td>
+                            <div class="d-flex flex-wrap gap-1">
+                                <a href="{{ url_for('main.community_edit', member_id=member.id) }}" 
+                                   class="btn btn-sm btn-outline-secondary" title="Edit">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <button type="button" class="btn btn-sm btn-outline-danger" title="Delete"
+                                        data-bs-toggle="modal" data-bs-target="#deleteModal" 
+                                        data-member-name="{{ member.name }}" data-form-id="delete-member-{{ member.id }}">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <form id="delete-member-{{ member.id }}" method="POST" 
+                                      action="{{ url_for('main.community_delete', member_id=member.id) }}" style="display:none;">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                </form>
+                            </div>
                         </td>
                     </tr>
                     {% endfor %}


### PR DESCRIPTION
### Motivation
- The community members table caused horizontal overflow on small viewports when rows were populated. 
- A minimal, local change to the template can let action buttons wrap rather than forcing a single-line layout. 
- Keep the change small and use existing Bootstrap utilities to avoid adding new CSS. 
- Preserve existing delete/edit behavior and modal wiring while fixing layout.

### Description
- Updated the actions cell in `app/templates/community/list.html` to remove `text-nowrap` and wrap the buttons in a `<div class="d-flex flex-wrap gap-1">` so they can wrap on narrow screens. 
- Removed the explicit `me-1` spacing on the edit button so spacing is handled by the `gap-1` utility. 
- No changes to backend code, forms, or modal handling were made; the delete form and modal attributes remain unchanged. 
- Only the template `app/templates/community/list.html` was modified.

### Testing
- Seed script run in development with `FLASK_ENV=development` to add sample members executed successfully. 
- Development server started with `FLASK_ENV=development ADMIN_PASSWORD=admin flask --app app:create_app run` and served the app successfully. 
- Automated Playwright script loaded `/community` at a mobile viewport and captured `artifacts/community-mobile.png`, which completed successfully. 
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959561739c88324903017aab9f09442)