### PR TITLE
Fix mobile nav panel width on small screens

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -198,8 +198,9 @@ h6,
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--elevation-2);
-  max-width: 360px;
-  margin-left: auto;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
 }
 
 .app-content {


### PR DESCRIPTION
### Motivation
- The mobile hamburger menu dropdown was pinned to the left and limited to a narrow `max-width: 360px`, so it did not span or center correctly on small devices. 
- The intended behavior is for the mobile nav panel to be full-width (or centered within the container) so items are readable and alignment matches the rest of the layout. 

### Description
- Updated `.app-mobile-nav-panel` in `app/static/css/app.css` to use `width: 100%`, `max-width: 100%`, and `margin: 0 auto` instead of `max-width: 360px` and `margin-left: auto` to allow the panel to expand and center on small screens. 
- This change is a CSS-only tweak and does not modify templates or JavaScript behavior. 

### Testing
- Started the development server with `FLASK_ENV=development FLASK_DEBUG=1 flask --app wsgi:app run` and it launched successfully. 
- Ran an automated Playwright script that opened `/login` at a mobile viewport, toggled the hamburger via `page.click('button.navbar-toggler')`, and captured a screenshot `artifacts/mobile-nav-full-width.png`, which was produced successfully. 
- No unit tests were added or modified because this is a style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595868dd8483248130e0bc6f738ba5)