### PR TITLE
Center mobile nav content on small screens

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -201,6 +201,25 @@ h6,
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
+  text-align: center;
+}
+
+.app-mobile-nav-panel .app-search,
+.app-mobile-nav-panel .nav {
+  width: 100%;
+}
+
+.app-mobile-nav-panel .app-search .form-control {
+  width: 100%;
+}
+
+.app-mobile-nav-panel .nav {
+  align-items: center;
+}
+
+.app-mobile-nav-panel .app-nav-link {
+  justify-content: center;
+  width: 100%;
 }
 
 .app-content {


### PR DESCRIPTION
### Motivation
- The mobile hamburger menu panel was left-aligned and inner content (nav links and search) did not span the full device width causing poor alignment and small tap targets on phones. 
- The intent is to center menu content and make search and links full-width on small screens for a consistent mobile UX.

### Description
- Updated `app/static/css/app.css` to add `text-align: center` to `.app-mobile-nav-panel` and make the panel content centered. 
- Forced `.app-mobile-nav-panel .app-search` and `.app-mobile-nav-panel .nav` to `width: 100%` and set `.app-mobile-nav-panel .app-search .form-control` to `width: 100%` so the search input uses the full width. 
- Centered nav items by adding `align-items: center` to the panel `.nav` and set `.app-mobile-nav-panel .app-nav-link` to `justify-content: center` and `width: 100%` to create full-width, centered tap targets. 

### Testing
- Installed dependencies with `pip install -r requirements.txt`, which completed successfully. 
- Launched the development server with `flask --app wsgi:app run --host 0.0.0.0 --port 5000` and it started successfully. 
- Ran a Playwright script that opened the app at a mobile viewport, toggled the hamburger, and produced a screenshot artifact (`artifacts/mobile-nav.png`) to verify the visual layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595b79bebc8324bc1fd9f8075046d9)