### PR TITLE
Add app version context and cache-bust static CSS

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,10 @@ csrf = CSRFProtect()
 
 def create_app():
     app = Flask(__name__)
+
+    @app.context_processor
+    def inject_app_version():
+        return {"app_version": os.environ.get("APP_VERSION", "dev")}
     
     # Load configuration
     from app.config import Config

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}SMS Admin{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="{{ url_for('static', filename='css/app.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/app.css', v=app_version) }}" rel="stylesheet">
 </head>
 <body class="app-body">
     <div class="app-shell">


### PR DESCRIPTION
### Motivation
- Ensure browsers pick up new front-end assets after deploys by adding a cache-busting version query parameter to static asset URLs.
- Provide a single `app_version` value available to templates sourced from an environment variable for easy stamp/versioning.

### Description
- Add a `@app.context_processor` in `create_app()` to inject `app_version` from `os.environ.get('APP_VERSION', 'dev')`.
- Update `app/templates/base.html` to append `v=app_version` to the CSS `url_for` call so the stylesheet URL becomes `url_for('static', filename='css/app.css', v=app_version)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596705f1208324bdb357135a11a7ff)