### PR TITLE
Align mobile hamburger menu content to the left

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -201,7 +201,7 @@ h6,
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
-  text-align: center;
+  text-align: left;
 }
 
 .app-mobile-nav-panel .app-search,
@@ -214,11 +214,11 @@ h6,
 }
 
 .app-mobile-nav-panel .nav {
-  align-items: center;
+  align-items: flex-start;
 }
 
 .app-mobile-nav-panel .app-nav-link {
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
 }
 


### PR DESCRIPTION
### Motivation
- Improve the mobile navigation UX by left-aligning the hamburger menu content to match the sidebar and common mobile patterns.
- Make menu items easier to scan and visually consistent with the rest of the app.

### Description
- Modified `app/static/css/app.css` to left-align the mobile nav panel by setting `.app-mobile-nav-panel { text-align: left; }`.
- Adjusted layout of the mobile nav container and links by changing `.app-mobile-nav-panel .nav { align-items: flex-start; }` and `.app-mobile-nav-panel .app-nav-link { justify-content: flex-start; }`.
- This is a scoped, CSS-only change with no template or JavaScript modifications.

### Testing
- Started the development server with `FLASK_ENV=development SCHEDULER_ENABLED=0 ADMIN_PASSWORD=admin flask --app wsgi:app run --debug --host 0.0.0.0 --port 5000` and confirmed the app served successfully.
- Executed a Playwright script that logs in, opens the hamburger menu on a mobile viewport, and saved a screenshot at `artifacts/mobile-nav-left.png`, which shows the updated left-aligned menu and succeeded.
- No unit tests were added because this is a UI/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596d6db1588324824ae28be6744138)