### PR TITLE
Improve accessibility: focus styles, aria-live feedback, and table skeleton loaders

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,7 +1,7 @@
 :root {
-  --color-primary: #0d6efd;
-  --color-primary-strong: #0b5ed7;
-  --color-accent: #6f42c1;
+  --color-primary: #0a58ca;
+  --color-primary-strong: #084298;
+  --color-accent: #59359f;
   --color-success: #198754;
   --color-warning: #ffc107;
   --color-danger: #dc3545;
@@ -11,7 +11,9 @@
   --color-surface-muted: #f8f9fa;
   --color-border: #dee2e6;
   --color-text: #212529;
-  --color-text-muted: #6c757d;
+  --color-text-muted: #495057;
+
+  --color-focus: #0b5ed7;
 
   --elevation-1: 0 0.125rem 0.25rem rgba(15, 23, 42, 0.08);
   --elevation-2: 0 0.5rem 1.25rem rgba(15, 23, 42, 0.12);
@@ -433,6 +435,38 @@ h6,
   box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.2);
 }
 
+.btn:focus-visible,
+.btn-close:focus-visible,
+.navbar-toggler:focus-visible,
+.form-control:focus-visible,
+.form-select:focus-visible,
+.form-check-input:focus-visible,
+.app-nav-link:focus-visible,
+a:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+.btn:disabled,
+.btn.disabled {
+  opacity: 0.65;
+}
+
+.form-check-input:checked {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.form-check-input:indeterminate {
+  background-color: var(--color-warning);
+  border-color: var(--color-warning);
+}
+
+.form-check-input:disabled {
+  opacity: 0.6;
+}
+
 .validation-message {
   border-radius: var(--radius-md);
   padding: var(--space-2) var(--space-3);
@@ -494,4 +528,38 @@ h6,
 
 .text-muted {
   color: var(--color-text-muted) !important;
+}
+
+.table-loading .table-skeleton-body {
+  display: none;
+}
+
+.table-loading.is-loading .table-data {
+  display: none;
+}
+
+.table-loading.is-loading .table-skeleton-body {
+  display: table-row-group;
+}
+
+.skeleton-block {
+  display: block;
+  height: 0.75rem;
+  background: linear-gradient(90deg, #e9ecef 25%, #f8f9fa 37%, #e9ecef 63%);
+  background-size: 400% 100%;
+  border-radius: var(--radius-sm);
+  animation: skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+.skeleton-block.skeleton-block--lg {
+  height: 1rem;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -149,6 +149,19 @@
             const toast = new bootstrap.Toast(toastEl);
             toast.show();
         });
+
+        const tableLoadingForms = document.querySelectorAll('form[data-table-loading-target]');
+        tableLoadingForms.forEach((form) => {
+            form.addEventListener('submit', () => {
+                const targetIds = form.dataset.tableLoadingTarget || '';
+                targetIds.split(',').map((id) => id.trim()).filter(Boolean).forEach((id) => {
+                    const target = document.getElementById(id);
+                    if (target) {
+                        target.classList.add('is-loading');
+                    }
+                });
+            });
+        });
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -20,7 +20,7 @@
 {% block content %}
 <div class="card app-card mb-4">
     <div class="card-body">
-        <form method="GET" class="filter-bar">
+        <form method="GET" class="filter-bar" data-table-loading-target="communityTable">
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -64,7 +64,7 @@
     </div>
     {% endif %}
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="communityTable">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -78,7 +78,7 @@
                     <th width="120">Actions</th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody class="table-data">
                 {% if members %}
                     {% for member in members %}
                     <tr>
@@ -121,6 +121,17 @@
                         </td>
                     </tr>
                 {% endif %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -116,6 +116,7 @@
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="client_timezone" id="client_timezone">
                         <div id="sendFormError" class="validation-message validation-message--error d-none" role="alert" aria-live="assertive"></div>
+                        <div id="sendFormStatus" class="visually-hidden" role="status" aria-live="polite" aria-atomic="true"></div>
                         <div class="mb-3">
                             <label for="message_body" class="form-label">Message</label>
                             <textarea class="form-control" id="message_body" name="message_body" rows="4"
@@ -281,6 +282,7 @@
     const sendForm = document.getElementById('sendForm');
     const sendBtn = document.getElementById('sendBtn');
     const sendFormError = document.getElementById('sendFormError');
+    const sendFormStatus = document.getElementById('sendFormStatus');
     const scheduleLater = document.getElementById('scheduleLater');
     const scheduleWrapper = document.getElementById('scheduleWrapper');
     const scheduleDate = document.getElementById('schedule_date');
@@ -365,6 +367,9 @@
         scheduleTime.classList.remove('is-invalid');
         document.getElementById('event_id').classList.remove('is-invalid');
         setValidationError('');
+        if (sendFormStatus) {
+            sendFormStatus.textContent = '';
+        }
     }
 
     sendForm.addEventListener('submit', function(event) {
@@ -398,14 +403,23 @@
         if (errors.length > 0) {
             event.preventDefault();
             setValidationError(errors[0]);
+            if (sendFormStatus) {
+                sendFormStatus.textContent = 'Please resolve the highlighted errors before sending.';
+            }
             return;
         }
 
         sendBtn.disabled = true;
         if (scheduleLater.checked) {
             sendBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Scheduling...';
+            if (sendFormStatus) {
+                sendFormStatus.textContent = 'Scheduling your message. Please wait.';
+            }
         } else {
             sendBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Sending...';
+            if (sendFormStatus) {
+                sendFormStatus.textContent = 'Sending your message. Please wait.';
+            }
         }
     });
 

--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -17,7 +17,7 @@
 {% block content %}
 <div class="card app-card mb-4">
     <div class="card-body">
-        <form class="filter-bar" method="GET">
+        <form class="filter-bar" method="GET" data-table-loading-target="eventsTable">
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -54,7 +54,7 @@
     </div>
     {% endif %}
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="eventsTable">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -69,7 +69,7 @@
                     <th width="120">Actions</th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody class="table-data">
                 {% if events %}
                     {% for event in events %}
                     <tr>
@@ -123,6 +123,18 @@
                         </td>
                     </tr>
                 {% endif %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -19,7 +19,7 @@
 {% block content %}
 <div class="card app-card mb-4">
     <div class="card-body">
-        <form class="filter-bar" method="GET">
+        <form class="filter-bar" method="GET" data-table-loading-target="logsTable">
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -56,7 +56,7 @@
     </div>
     {% endif %}
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="logsTable">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -71,7 +71,7 @@
                     <th width="80"></th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody class="table-data">
                 {% if logs %}
                 {% for log in logs %}
                 <tr>
@@ -119,6 +119,18 @@
                     </td>
                 </tr>
                 {% endif %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>

--- a/app/templates/scheduled/list.html
+++ b/app/templates/scheduled/list.html
@@ -19,7 +19,7 @@
 
 <div class="card app-card mb-4">
     <div class="card-body">
-        <form class="filter-bar" method="GET">
+        <form class="filter-bar" method="GET" data-table-loading-target="scheduledTables,scheduledPastTable">
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0" data-bulk-scope="pending">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledTables" data-bulk-scope="pending">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -70,7 +70,7 @@
                     <th width="150">Actions</th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody class="table-data">
                 {% for msg in pending %}
                 <tr>
                     <td>
@@ -107,6 +107,17 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         </form>
                     </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -175,7 +186,7 @@
         </div>
     </div>
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0" data-bulk-scope="past">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledPastTable" data-bulk-scope="past">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -188,7 +199,7 @@
                     <th width="100">Actions</th>
                 </tr>
             </thead>
-            <tbody>
+            <tbody class="table-data">
                 {% for msg in past %}
                 <tr>
                     <td>
@@ -237,6 +248,18 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         </form>
                     </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-25"></span></td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
### Motivation
- Improve visible focus and keyboard accessibility by adding clear focus outlines and stronger contrast tokens.
- Make button and checkbox states more obvious so users can reliably see disabled/checked/indeterminate states.
- Provide immediate ARIA feedback during long submit actions (sending/scheduling) to help screen reader users.
- Surface loading state for data tables with skeleton rows so users get responsive feedback while list views update.

### Description
- Updated theme tokens in `app/static/css/app.css` (primary/strong/accent/text-muted) and added a `--color-focus` token for consistent focus rings.
- Added `:focus-visible` rules, improved checkbox/button disabled/checked/indeterminate visuals, and contrast/opacity tweaks in `app/static/css/app.css` to meet WCAG AA intent.
- Implemented skeleton/shimmer styles and table-loading helpers in `app/static/css/app.css` and added skeleton `<tbody>` blocks to list templates (`community`, `events`, `logs`, `scheduled`) with `table-loading` classes and IDs.
- Added a hidden ARIA status region `#sendFormStatus` to the dashboard and updated dashboard JS to set aria-live messages during validation, sending, and scheduling, and added a generic form hook in `base.html` that toggles `.is-loading` on target tables when filter forms submit.

### Testing
- Started the development server and exercised the UI (Flask dev server started successfully using `FLASK_ENV=development ADMIN_PASSWORD=admin flask --app wsgi:app run --debug --host 0.0.0.0 --port 5000`).
- Ran an automated Playwright script that logged in and captured a dashboard screenshot to validate visual changes, and the script completed and produced a screenshot successfully.
- No backend unit tests were changed or run as these are front-end/UI improvements only.
- Verified template and CSS changes loaded in the running app (manual verification via browser screenshot as above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695977a9a508832482455c9f82435fde)