### PR TITLE
Update dashboard event registration label

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -23,7 +23,7 @@
                             <div class="text-muted text-uppercase small">Total recipients</div>
                             <div class="fs-4 fw-semibold">{{ total_recipients }}</div>
                             <div class="text-muted small">
-                                Community {{ community_count }} • Event regs {{ event_registration_count }}
+                                Community {{ community_count }} • Event registrations {{ event_registration_count }}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Keep dashboard labels consistent by expanding the shorthand `Event regs` to the full phrase `Event registrations`.
- Improve clarity for users reading the overview card.
- Make a minimal, localized change to the UI copy.

### Description
- Replace the text in `app/templates/dashboard.html` from `Event regs` to `Event registrations` on the overview card line.
- The resulting line is `Community {{ community_count }} • Event registrations {{ event_registration_count }}`.
- Verified no other templates use the shorthand using `rg -n "Event reg"` and `rg -n "Event regs|Event reg"`.
- No new code paths or dependencies were introduced.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598539652083249ab3cf6351bc9f7e)