### PR TITLE
Add unittest coverage for phone normalization and CSV parsing utilities

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,77 @@
+"""Unit tests for app.utils.
+
+Run with: python -m unittest tests.test_utils
+"""
+
+import unittest
+
+from app.utils import (
+    normalize_phone,
+    validate_phone,
+    parse_recipients_csv,
+    parse_phones_csv,
+)
+
+
+class TestNormalizePhone(unittest.TestCase):
+    def test_us_number_without_country_code(self) -> None:
+        self.assertEqual(normalize_phone("720-383-2388"), "+17203832388")
+
+    def test_us_number_with_country_code(self) -> None:
+        self.assertEqual(normalize_phone("+1 (720) 383-2388"), "+17203832388")
+
+    def test_number_with_punctuation(self) -> None:
+        self.assertEqual(normalize_phone("(310) 555-1212"), "+13105551212")
+
+
+class TestValidatePhone(unittest.TestCase):
+    def test_valid_e164(self) -> None:
+        self.assertTrue(validate_phone("+14155552671"))
+
+    def test_invalid_short(self) -> None:
+        self.assertFalse(validate_phone("12345"))
+
+    def test_invalid_long(self) -> None:
+        self.assertFalse(validate_phone("+1234567890123456"))
+
+    def test_empty(self) -> None:
+        self.assertFalse(validate_phone(""))
+
+
+class TestParseRecipientsCsv(unittest.TestCase):
+    def test_single_column_phone_only(self) -> None:
+        content = "720-383-2388\n\n123\n"
+        self.assertEqual(
+            parse_recipients_csv(content),
+            [{"name": None, "phone": "+17203832388"}],
+        )
+
+    def test_two_column_name_phone_and_phone_name(self) -> None:
+        content = "Name,Phone\nAlice,720-383-2388\n720-555-1212,Bob\nNope,StillNo\n"
+        self.assertEqual(
+            parse_recipients_csv(content),
+            [
+                {"name": "Alice", "phone": "+17203832388"},
+                {"name": "Bob", "phone": "+17205551212"},
+            ],
+        )
+
+    def test_three_column_first_last_phone_with_header(self) -> None:
+        content = "First,Last,Phone\nVardan,Hovsepyan,(323) 630-0201\n,,\nBad,Data,123\n"
+        self.assertEqual(
+            parse_recipients_csv(content),
+            [{"name": "Vardan Hovsepyan", "phone": "+13236300201"}],
+        )
+
+
+class TestParsePhonesCsv(unittest.TestCase):
+    def test_multiple_numbers_per_row_mixed_formatting(self) -> None:
+        content = "720-383-2388,(310) 555-1212\ninvalid,123\n\n+1 415 555 2671\n"
+        self.assertEqual(
+            parse_phones_csv(content),
+            ["+17203832388", "+13105551212", "+14155552671"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Add focused tests to increase confidence in phone-related utilities (`normalize_phone`, `validate_phone`, `parse_recipients_csv`, `parse_phones_csv`).
- Ensure parsing and normalization handle common US formats, punctuation, headers, and mixed CSV layouts. 
- Keep changes minimal and avoid new dependencies by using the standard library `unittest` framework.

### Description
- Add a new test module `tests/test_utils.py` implementing unit tests for `normalize_phone`, `validate_phone`, `parse_recipients_csv`, and `parse_phones_csv`.
- Cover scenarios including US numbers with and without country code, numbers containing punctuation, valid and invalid E.164 inputs, and CSV formats with 1/2/3+ columns and headers.
- Include edge cases for empty lines and invalid numbers, and document the test run command in the module docstring.
- Tests are written with the built-in `unittest` framework to avoid adding dependencies.

### Testing
- Run `python -m unittest tests.test_utils` which executed the new test module.
- The test run reported `Ran 11 tests` and completed with status `OK`.
- No other automated tests were modified or run as part of this change.
- All added tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598562999083248ff6b7ba1a4d2018)