### PR TITLE
Add search filters to events, logs, and scheduled lists

### DIFF
--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -21,7 +21,7 @@
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
-                    <input type="text" class="form-control" name="search" placeholder="Search events">
+                    <input type="text" class="form-control" name="search" placeholder="Search events" value="{{ search }}">
                 </div>
             </div>
             <div class="filter-chip-group">

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -23,7 +23,7 @@
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
-                    <input type="text" class="form-control" name="search" placeholder="Search logs">
+                    <input type="text" class="form-control" name="search" placeholder="Search logs" value="{{ search }}">
                 </div>
             </div>
             <div class="filter-chip-group">

--- a/app/templates/scheduled/list.html
+++ b/app/templates/scheduled/list.html
@@ -23,7 +23,7 @@
             <div class="flex-grow-1">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
-                    <input type="text" class="form-control" name="search" placeholder="Search scheduled messages">
+                    <input type="text" class="form-control" name="search" placeholder="Search scheduled messages" value="{{ search }}">
                 </div>
             </div>
             <div class="filter-chip-group">


### PR DESCRIPTION
### Motivation
- Allow users to search/filter the Events, Message Logs, and Scheduled Messages list pages using the `search` query parameter.
- Enable matching against event titles from related tables when searching logs and scheduled messages.
- Preserve existing behavior when the `search` parameter is empty so no results change.
- Keep the search input populated after submission so the query is retained in the UI.

### Description
- `events_list` now reads `search = request.args.get('search', '').strip()` and filters with `Event.title.ilike(...)` and `db.cast(Event.date, db.String).ilike(...)` when present.
- `logs_list` now reads `search`, outer-joins `Event`, and filters `MessageLog.message_body`, `MessageLog.target`, and `Event.title` when a search term is provided.
- `scheduled_list` now reads `search`, outer-joins `Event`, and filters `ScheduledMessage.message_body`, `ScheduledMessage.target`, and `Event.title`, and uses that filtered query for pending and past sets.
- Templates `app/templates/events/list.html`, `app/templates/logs/list.html`, and `app/templates/scheduled/list.html` were updated to pass the `search` value back into the search input (`value="{{ search }}"`).

### Testing
- No automated tests were run.
- Commands executed during the change include `sed`/file inspections, `rg` for searching symbols, and `git add` / `git commit -m "Add search filtering for lists"` to record the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959855eeca883249b4fcfcc9ee02cc7)