### PR TITLE
Fix bulk selection count for visible members

### DIFF
--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -260,8 +260,15 @@
     const bulkDeleteBtn = document.getElementById('bulkDeleteBtn');
     const bulkActionBar = document.getElementById('bulkActionBar');
 
+    function isElementVisible(element) {
+        if (!element) return false;
+        if (element.offsetParent !== null) return true;
+        return element.getClientRects().length > 0;
+    }
+
     function getMemberCheckboxes() {
-        return Array.from(document.querySelectorAll('.member-checkbox'));
+        return Array.from(document.querySelectorAll('.member-checkbox'))
+            .filter(isElementVisible);
     }
 
     function updateBulkUi() {


### PR DESCRIPTION
### Motivation
- The bulk-selection UI was double-counting members because both the table and card list render checkboxes and hidden duplicates were being included in selection operations.
- This caused `selectedCount` and the bulk-delete modal to report roughly twice the real number of members on responsive views.
- The goal is to scope bulk operations to only visible checkboxes so counts and actions reflect what the user actually sees.
- The change is intentionally small and non-invasive to avoid affecting existing forms or behavior.

### Description
- Added an `isElementVisible(element)` helper that returns true when an element is visible via `offsetParent` or `getClientRects()` checks.
- Updated `getMemberCheckboxes()` to return only `.member-checkbox` elements that pass `isElementVisible` so hidden duplicates are ignored.
- No markup or dependency changes were introduced and existing `form` attributes and input values are preserved.
- Files inspected and commands used during the fix include `sed -n '1,220p' app/templates/community/list.html`, `sed -n '220,520p' app/templates/community/list.html`, and `git status -sb`.

### Testing
- No automated tests were run for this change.
- Please run the project’s automated test suite and perform responsive UI checks to validate selection counts across breakpoints before deploying.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69599197f7e88324aaba75a260136d7a)