### PR TITLE
Use delegated change listener for member checkboxes

### DIFF
--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -322,8 +322,10 @@
         });
     }
 
-    getMemberCheckboxes().forEach(b => {
-        b.addEventListener('change', updateBulkUi);
+    document.addEventListener('change', function(event) {
+        if (event.target && event.target.classList.contains('member-checkbox')) {
+            updateBulkUi();
+        }
     });
 
     const bulkDeleteModal = document.getElementById('bulkDeleteModal');


### PR DESCRIPTION
### Motivation
- Because `getMemberCheckboxes()` filters out non-visible checkboxes, checkbox change handlers previously attached with `getMemberCheckboxes().forEach(...)` only covered checkboxes visible at initial load.
- When the viewport is resized (Bootstrap toggles such as `d-lg-none`/`d-lg-block`) newly visible checkboxes lacked a `change` handler, breaking the bulk selection UI state.
- A delegated listener ensures checkbox changes are handled regardless of which DOM nodes are currently visible.

### Description
- Replace per-checkbox binding `getMemberCheckboxes().forEach(b => b.addEventListener('change', updateBulkUi));` with a delegated document-level `change` listener that calls `updateBulkUi()` when `event.target.classList.contains('member-checkbox')`.
- Update `app/templates/community/list.html` to add the delegated listener and remove the direct iteration binding.
- No other UI logic or selection behavior was modified.

### Testing
- No automated tests were run for this change.
- I inspected and updated `app/templates/community/list.html` and committed the change with `git commit -m "Fix bulk selection on resized view"`.
- Commands run during validation include `ls`, `cat AGENTS.md`, `rg -n "getMemberCheckboxes"`, `sed -n '240,360p'`, and applying the patch via the repository tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959a9ed808c8324b9ece3d4607faa31)