### PR TITLE
Stretch bulk action buttons on mobile

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -353,6 +353,31 @@ h6,
   display: flex;
 }
 
+@media (max-width: 576px) {
+  .bulk-action-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .bulk-action-bar > .d-flex {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .bulk-action-bar .btn-group {
+    width: 100%;
+  }
+
+  .bulk-action-bar .btn-group .btn {
+    flex: 1 1 auto;
+  }
+
+  .bulk-action-bar .btn {
+    white-space: nowrap;
+  }
+}
+
 .row-actions {
   opacity: 0;
   transition: opacity 0.2s ease-in-out;


### PR DESCRIPTION
### Motivation
- Ensure the bulk-selection controls line up and fill the available width on narrow viewports so the UI is less cramped and more consistent. 
- Prevent awkward wrapping or misalignment of `Select All`, `Select None`, and `Invert` controls when the view collapses to the `.card-list` layout. 
- Keep changes purely presentational so pages that reuse `.bulk-action-bar` don't require markup changes.

### Description
- Add a `@media (max-width: 576px)` block in `app/static/css/app.css` to adjust the mobile layout.
- Make `.bulk-action-bar` use `flex-direction: column` and `align-items: stretch` on small screens.
- Force `.bulk-action-bar > .d-flex` and `.bulk-action-bar .btn-group` to `width: 100%` and make `.bulk-action-bar .btn-group .btn` use `flex: 1 1 auto` so buttons distribute evenly across the row.
- Preserve `white-space: nowrap` on `.bulk-action-bar .btn` to avoid excessive text wrapping.

### Testing
- Started the dev server with `FLASK_ENV=development ADMIN_PASSWORD=admin SECRET_KEY=dev python -m flask --app wsgi:app run --debug --host 0.0.0.0 --port 5000` and the app served successfully. 
- Ran a Playwright script (viewport `375x812`) that logs in, navigates to `/community`, selects a member, and captured a mobile screenshot which completed and produced `artifacts/bulk-action-bar-mobile.png` successfully. 
- The CSS change is present in `app/static/css/app.css` and no runtime errors were observed while exercising the relevant UI paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b163b3748324a23af100205bed4e)