### PR TITLE
Add role-based user management

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,39 @@
 from datetime import datetime as dt, timezone
+from flask_login import UserMixin
+from werkzeug.security import check_password_hash, generate_password_hash
 from app import db
 
 
 def utc_now():
     return dt.now(timezone.utc)
+
+
+class AppUser(UserMixin, db.Model):
+    """Application users with role-based access."""
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), nullable=False, unique=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    role = db.Column(db.String(30), nullable=False, default='admin')
+    created_at = db.Column(db.DateTime, default=utc_now)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    @property
+    def is_admin(self) -> bool:
+        return self.role == 'admin'
+
+    @property
+    def is_social_manager(self) -> bool:
+        return self.role == 'social_manager'
+
+    def __repr__(self):
+        return f'<AppUser {self.username} role={self.role}>'
 
 
 class CommunityMember(db.Model):

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -38,6 +38,11 @@
                 <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
                     <i class="bi bi-journal-text me-2"></i>Logs
                 </a>
+                {% if current_user.is_authenticated and current_user.is_admin %}
+                <a class="app-nav-link {% if 'users' in request.endpoint %}active{% endif %}" href="{{ url_for('main.users_list') }}">
+                    <i class="bi bi-person-gear me-2"></i>Users
+                </a>
+                {% endif %}
             </nav>
             {% if current_user.is_authenticated %}
             <div class="mt-auto">
@@ -82,6 +87,11 @@
                             <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
                                 <i class="bi bi-journal-text me-2"></i>Logs
                             </a>
+                            {% if current_user.is_authenticated and current_user.is_admin %}
+                            <a class="app-nav-link {% if 'users' in request.endpoint %}active{% endif %}" href="{{ url_for('main.users_list') }}">
+                                <i class="bi bi-person-gear me-2"></i>Users
+                            </a>
+                            {% endif %}
                             {% if current_user.is_authenticated %}
                             <a class="app-nav-link mt-2" href="{{ url_for('auth.logout') }}">
                                 <i class="bi bi-box-arrow-right me-2"></i>Logout

--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -4,17 +4,21 @@
 
 {% block page_title %}Community Members{% endblock %}
 
+{% set can_manage_community = current_user.is_admin %}
+
 {% block breadcrumbs %}
 <a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Community</span>
 {% endblock %}
 
 {% block page_actions %}
+{% if can_manage_community %}
 <a href="{{ url_for('main.community_import') }}" class="btn btn-outline-primary">
     <i class="bi bi-upload me-1"></i>Import CSV
 </a>
 <a href="{{ url_for('main.community_add') }}" class="btn btn-primary">
     <i class="bi bi-plus-lg me-1"></i>Add Member
 </a>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -41,7 +45,7 @@
 </div>
 
 <div class="card app-card">
-    {% if members %}
+    {% if members and can_manage_community %}
     <div class="bulk-action-bar" id="bulkActionBar">
         <div class="d-flex align-items-center gap-2">
             <span class="badge bg-primary"><span id="selectedCount">0</span> selected</span>
@@ -67,27 +71,34 @@
         <table class="table table-hover table-sticky-header mb-0 table-loading" id="communityTable">
             <thead class="table-light">
                 <tr>
+                    {% if can_manage_community %}
                     <th width="40">
                         {% if members %}
                         <input class="form-check-input" type="checkbox" id="selectAllMembers" aria-label="Select all members">
                         {% endif %}
                     </th>
+                    {% endif %}
                     <th>Name</th>
                     <th>Phone</th>
                     <th>Added</th>
+                    {% if can_manage_community %}
                     <th width="120">Actions</th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody class="table-data">
                 {% if members %}
                     {% for member in members %}
                     <tr>
+                        {% if can_manage_community %}
                         <td>
                             <input class="form-check-input member-checkbox js-select-row" type="checkbox" name="member_ids" value="{{ member.id }}" form="bulkDeleteForm" aria-label="Select member">
                         </td>
+                        {% endif %}
                         <td>{{ member.name or '-' }}</td>
                         <td><code>{{ member.phone }}</code></td>
                         <td>{{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</td>
+                        {% if can_manage_community %}
                         <td>
                             <div class="d-flex flex-wrap gap-1 row-actions">
                                 <button type="button" class="btn btn-sm btn-outline-primary"
@@ -110,14 +121,17 @@
                                 </form>
                             </div>
                         </td>
+                        {% endif %}
                     </tr>
                     {% endfor %}
                 {% else %}
                     <tr>
-                        <td colspan="5" class="text-center text-muted py-4">
+                        <td colspan="{{ 5 if can_manage_community else 3 }}" class="text-center text-muted py-4">
                             No community members found.
-                            <a href="{{ url_for('main.community_add') }}">Add one</a> or 
+                            {% if can_manage_community %}
+                            <a href="{{ url_for('main.community_add') }}">Add one</a> or
                             <a href="{{ url_for('main.community_import') }}">import from CSV</a>.
+                            {% endif %}
                         </td>
                     </tr>
                 {% endif %}
@@ -145,9 +159,12 @@
                         <div class="text-muted small"><code>{{ member.phone }}</code></div>
                         <div class="text-muted small">Added {{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</div>
                     </div>
+                    {% if can_manage_community %}
                     <input class="form-check-input member-checkbox js-select-row" type="checkbox" name="member_ids"
                            value="{{ member.id }}" form="bulkDeleteForm" aria-label="Select member">
+                    {% endif %}
                 </div>
+                {% if can_manage_community %}
                 <div class="d-flex flex-wrap gap-2 mt-3 row-actions">
                     <button type="button" class="btn btn-sm btn-outline-primary"
                             data-bs-toggle="offcanvas" data-bs-target="#memberPreview{{ member.id }}"
@@ -163,13 +180,16 @@
                         <i class="bi bi-trash"></i> Delete
                     </button>
                 </div>
+                {% endif %}
             </div>
             {% endfor %}
         {% else %}
             <div class="text-center text-muted py-4">
                 No community members found.
+                {% if can_manage_community %}
                 <a href="{{ url_for('main.community_add') }}">Add one</a> or
                 <a href="{{ url_for('main.community_import') }}">import from CSV</a>.
+                {% endif %}
             </div>
         {% endif %}
     </div>
@@ -180,7 +200,7 @@
     {% endif %}
 </div>
 
-{% if members %}
+{% if members and can_manage_community %}
     {% for member in members %}
     <div class="offcanvas offcanvas-end preview-panel" tabindex="-1" id="memberPreview{{ member.id }}">
         <div class="offcanvas-header">
@@ -196,6 +216,7 @@
     {% endfor %}
 {% endif %}
 
+{% if can_manage_community %}
 <!-- Delete Confirmation Modal -->
 <div class="modal fade" id="deleteModal" tabindex="-1">
     <div class="modal-dialog modal-sm">
@@ -232,9 +253,11 @@
         </div>
     </div>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}
+{% if can_manage_community %}
 <script>
     let formToSubmit = null;
     const deleteModal = document.getElementById('deleteModal');
@@ -349,4 +372,5 @@
 
     updateBulkUi();
 </script>
+{% endif %}
 {% endblock %}

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block page_actions %}
-{% if logs %}
+{% if logs and current_user.is_admin %}
 <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#clearLogsModal">
     <i class="bi bi-trash me-1"></i>Clear All Logs
 </button>
@@ -189,6 +189,7 @@
     {% endfor %}
 {% endif %}
 
+{% if current_user.is_admin %}
 <!-- Clear Logs Modal -->
 <div class="modal fade" id="clearLogsModal" tabindex="-1">
     <div class="modal-dialog">
@@ -218,6 +219,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/app/templates/users/form.html
+++ b/app/templates/users/form.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}{{ 'Edit' if user else 'Create' }} User - SMS Admin{% endblock %}
+
+{% block page_title %}{{ 'Edit' if user else 'Create' }} User{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.users_list') }}">Users</a> /
+<span>{{ 'Edit' if user else 'Create' }}</span>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card app-card">
+            <div class="card-header">
+                <h5 class="mb-0">
+                    <i class="bi bi-person-gear me-2"></i>{{ 'Edit' if user else 'Create' }} User
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="username" class="form-label">Username <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="username" name="username" required
+                               value="{{ user.username if user else '' }}"
+                               placeholder="username">
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="role" class="form-label">Role <span class="text-danger">*</span></label>
+                        <select class="form-select" id="role" name="role" required>
+                            <option value="" disabled {% if not user %}selected{% endif %}>Select role</option>
+                            <option value="admin" {% if user and user.role == 'admin' %}selected{% endif %}>Admin</option>
+                            <option value="social_manager" {% if user and user.role == 'social_manager' %}selected{% endif %}>Social Media Manager</option>
+                        </select>
+                    </div>
+
+                    <div class="mb-4">
+                        <label for="password" class="form-label">
+                            {{ 'New Password' if user else 'Password' }}{% if not user %} <span class="text-danger">*</span>{% endif %}
+                        </label>
+                        <input type="password" class="form-control" id="password" name="password" {% if not user %}required{% endif %}>
+                        {% if user %}
+                        <div class="form-text">Leave blank to keep the existing password.</div>
+                        {% endif %}
+                    </div>
+
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i>{{ 'Update' if user else 'Create' }} User
+                        </button>
+                        <a href="{{ url_for('main.users_list') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+
+{% block title %}Users - SMS Admin{% endblock %}
+
+{% block page_title %}Users{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Users</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.users_add') }}" class="btn btn-primary">
+    <i class="bi bi-plus-lg me-1"></i>Add User
+</a>
+{% endblock %}
+
+{% block content %}
+<div class="card app-card">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th>Username</th>
+                    <th>Role</th>
+                    <th>Created</th>
+                    <th width="140">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if users %}
+                    {% for user in users %}
+                    <tr>
+                        <td>
+                            {{ user.username }}
+                            {% if current_user.id == user.id %}
+                                <span class="badge bg-secondary ms-2">You</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge bg-{{ 'primary' if user.is_admin else 'info' }}">
+                                {{ 'Admin' if user.is_admin else 'Social Media Manager' }}
+                            </span>
+                        </td>
+                        <td>{{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '-' }}</td>
+                        <td>
+                            <div class="d-flex flex-wrap gap-1">
+                                <a href="{{ url_for('main.users_edit', user_id=user.id) }}" class="btn btn-sm btn-outline-secondary">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                        data-bs-toggle="modal" data-bs-target="#deleteUserModal"
+                                        data-username="{{ user.username }}"
+                                        data-form-id="delete-user-{{ user.id }}"
+                                        {% if current_user.id == user.id %}disabled{% endif %}>
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <form id="delete-user-{{ user.id }}" method="POST"
+                                      action="{{ url_for('main.users_delete', user_id=user.id) }}" style="display:none;">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="4" class="text-center text-muted py-4">
+                            No users found.
+                        </td>
+                    </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+    {% if users %}
+    <div class="card-footer text-muted">
+        Showing {{ users|length }} user(s)
+    </div>
+    {% endif %}
+</div>
+
+<div class="modal fade" id="deleteUserModal" tabindex="-1">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Delete <strong id="deleteUsername"></strong>?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteUserBtn">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    let userFormToSubmit = null;
+    const deleteUserModal = document.getElementById('deleteUserModal');
+
+    if (deleteUserModal) {
+        deleteUserModal.addEventListener('show.bs.modal', function(event) {
+            const button = event.relatedTarget;
+            const username = button.getAttribute('data-username') || 'this user';
+            const formId = button.getAttribute('data-form-id');
+
+            document.getElementById('deleteUsername').textContent = username;
+            userFormToSubmit = document.getElementById(formId);
+        });
+    }
+
+    const confirmDeleteUserBtn = document.getElementById('confirmDeleteUserBtn');
+    if (confirmDeleteUserBtn) {
+        confirmDeleteUserBtn.addEventListener('click', function() {
+            if (userFormToSubmit) {
+                userFormToSubmit.submit();
+            }
+        });
+    }
+</script>
+{% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,8 +1,6 @@
 import re
 import csv
 import io
-import hmac
-from werkzeug.security import check_password_hash
 
 
 def normalize_phone(phone: str) -> str:
@@ -151,13 +149,3 @@ def parse_phones_csv(file_content: str) -> list:
     
     return phones
 
-
-def verify_admin_password(stored_password: str, provided_password: str) -> bool:
-    """Verify admin password with support for hashed values."""
-    if not stored_password or not provided_password:
-        return False
-
-    if stored_password.startswith(('pbkdf2:', 'scrypt:')):
-        return check_password_hash(stored_password, provided_password)
-
-    return hmac.compare_digest(stored_password, provided_password)


### PR DESCRIPTION
### Motivation
- Provide CRUD for application users so Admins can manage accounts and grant limited access to Social Media Managers.
- Enforce role-based permissions so Social Media Managers can send messages but cannot add/delete community members or manage users.
- Seed an initial admin user from environment credentials to allow first-time setup without manual DB changes.

### Description
- Add `AppUser` SQLAlchemy model with `username`, `password_hash`, `role`, helper methods, and `UserMixin` integration for Flask-Login.
- Implement admin-only user CRUD routes (`/users`, `/users/add`, `/users/<id>/edit`, `/users/<id>/delete`) and add `users` templates (`users/list.html`, `users/form.html`).
- Add `require_roles` decorator and wire role checks into routes and templates to restrict community management and log-clearing to admins, plus prevent deleting the last admin or the current user.
- Seed the first admin on app startup from `ADMIN_USERNAME`/`ADMIN_PASSWORD` (hashed if necessary) and update auth to use `AppUser` instead of the old single-admin check.

### Testing
- Started the development server with `FLASK_ENV=development ADMIN_PASSWORD=admin SECRET_KEY=dev flask --app wsgi:app run --debug` and confirmed the app booted and DB tables were created.
- Ran a headless browser script to log in (`admin` / `admin`) and navigate to `/users`, which returned HTTP 200 and produced a screenshot of the users list (`artifacts/users-list.png`).
- Verified UI changes: Users nav appears for admins and community management actions are hidden for non-admin views during manual checks; no automated unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8d92af788324b4c9010a062a9340)