### PR TITLE
Prevent mobile form zoom on focus

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -448,6 +448,15 @@ h6,
   font-size: var(--font-size-2);
 }
 
+@media (max-width: 768px) {
+  .form-control,
+  .form-select,
+  .form-check-input,
+  .input-group-text {
+    font-size: var(--font-size-3);
+  }
+}
+
 .form-control,
 .form-select {
   padding: var(--space-2) var(--space-3);


### PR DESCRIPTION
### Motivation
- On iOS Safari and some mobile browsers, inputs with font-size below ~16px cause the page to zoom when a text field receives focus, degrading the mobile UX when editing/adding users.
- Raise mobile form control font size to avoid automatic zoom on focus while keeping desktop styling unchanged.

### Description
- Added a small media query to `app/static/css/app.css` that targets `@media (max-width: 768px)` and increases the font-size for `.form-control`, `.form-select`, `.form-check-input`, and `.input-group-text`.
- The rule uses `var(--font-size-3)` (1rem / ~16px) so the change only affects small screens and preserves existing desktop sizes.

### Testing
- Created a virtual environment and installed dependencies via `python -m venv .venv` and `pip install -r requirements.txt`, which completed successfully.
- Launched the dev server with `FLASK_ENV=development ADMIN_PASSWORD=admin123 flask --app wsgi:app run --host 0.0.0.0 --port 5000` and confirmed pages are served.
- Automated browser check using Playwright navigated to the add-user form at a mobile viewport and saved `artifacts/users-add-mobile.png`, which shows the updated styles applied.
- No unit tests were modified and no additional automated unit test suite was run because this is a style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7b2403b083249d603c65453cf647)