### PR TITLE
Add unsubscribe suppression, management UI, and CSV exports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,20 @@ class CommunityMember(db.Model):
         return f'<CommunityMember {self.phone}>'
 
 
+class UnsubscribedContact(db.Model):
+    """Phone numbers that should not receive messages."""
+    __tablename__ = 'unsubscribed_contacts'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=True)
+    phone = db.Column(db.String(20), nullable=False, unique=True)
+    source = db.Column(db.String(50), nullable=False, default='manual')
+    created_at = db.Column(db.DateTime, default=utc_now)
+
+    def __repr__(self):
+        return f'<UnsubscribedContact {self.phone}>'
+
+
 class Event(db.Model):
     """Event definitions."""
     __tablename__ = 'events'

--- a/app/services/recipient_service.py
+++ b/app/services/recipient_service.py
@@ -1,0 +1,23 @@
+from typing import Iterable
+
+
+def get_unsubscribed_phone_set(phones: Iterable[str]) -> set[str]:
+    phones = {phone for phone in phones if phone}
+    if not phones:
+        return set()
+
+    from app.models import UnsubscribedContact
+
+    unsubscribed = UnsubscribedContact.query.filter(UnsubscribedContact.phone.in_(phones)).all()
+    return {entry.phone for entry in unsubscribed}
+
+
+def filter_unsubscribed_recipients(recipients: list[dict]) -> tuple[list[dict], list[dict], set[str]]:
+    phones = [recipient.get('phone') for recipient in recipients if recipient.get('phone')]
+    unsubscribed_phones = get_unsubscribed_phone_set(phones)
+    if not unsubscribed_phones:
+        return recipients, [], set()
+
+    filtered = [recipient for recipient in recipients if recipient.get('phone') not in unsubscribed_phones]
+    skipped = [recipient for recipient in recipients if recipient.get('phone') in unsubscribed_phones]
+    return filtered, skipped, unsubscribed_phones

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,6 +29,9 @@
                 <a class="app-nav-link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
                     <i class="bi bi-people me-2"></i>Community
                 </a>
+                <a class="app-nav-link {% if 'unsubscribed' in request.endpoint %}active{% endif %}" href="{{ url_for('main.unsubscribed_list') }}">
+                    <i class="bi bi-person-x me-2"></i>Unsubscribed
+                </a>
                 <a class="app-nav-link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
                     <i class="bi bi-calendar-event me-2"></i>Events
                 </a>
@@ -77,6 +80,9 @@
                             </a>
                             <a class="app-nav-link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
                                 <i class="bi bi-people me-2"></i>Community
+                            </a>
+                            <a class="app-nav-link {% if 'unsubscribed' in request.endpoint %}active{% endif %}" href="{{ url_for('main.unsubscribed_list') }}">
+                                <i class="bi bi-person-x me-2"></i>Unsubscribed
                             </a>
                             <a class="app-nav-link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
                                 <i class="bi bi-calendar-event me-2"></i>Events

--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -15,6 +15,9 @@
 <a href="{{ url_for('main.community_import') }}" class="btn btn-outline-primary">
     <i class="bi bi-upload me-1"></i>Import CSV
 </a>
+<a href="{{ url_for('main.community_export') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-download me-1"></i>Export CSV
+</a>
 <a href="{{ url_for('main.community_add') }}" class="btn btn-primary">
     <i class="bi bi-plus-lg me-1"></i>Add Member
 </a>
@@ -80,6 +83,7 @@
                     {% endif %}
                     <th>Name</th>
                     <th>Phone</th>
+                    <th>Status</th>
                     <th>Added</th>
                     {% if can_manage_community %}
                     <th width="120">Actions</th>
@@ -89,6 +93,7 @@
             <tbody class="table-data">
                 {% if members %}
                     {% for member in members %}
+                    {% set is_unsubscribed = member.phone in unsubscribed_phones %}
                     <tr>
                         {% if can_manage_community %}
                         <td>
@@ -97,6 +102,13 @@
                         {% endif %}
                         <td>{{ member.name or '-' }}</td>
                         <td><code>{{ member.phone }}</code></td>
+                        <td>
+                            {% if is_unsubscribed %}
+                            <span class="badge bg-secondary">Unsubscribed</span>
+                            {% else %}
+                            <span class="badge bg-success">Active</span>
+                            {% endif %}
+                        </td>
                         <td>{{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</td>
                         {% if can_manage_community %}
                         <td>
@@ -110,6 +122,14 @@
                                    class="btn btn-sm btn-outline-secondary" title="Edit">
                                     <i class="bi bi-pencil"></i>
                                 </a>
+                                {% if not is_unsubscribed %}
+                                <form method="POST" action="{{ url_for('main.community_unsubscribe', member_id=member.id) }}" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-sm btn-outline-warning" title="Unsubscribe">
+                                        <i class="bi bi-person-x"></i>
+                                    </button>
+                                </form>
+                                {% endif %}
                                 <button type="button" class="btn btn-sm btn-outline-danger" title="Delete"
                                         data-bs-toggle="modal" data-bs-target="#deleteModal" 
                                         data-member-name="{{ member.name }}" data-form-id="delete-member-{{ member.id }}">
@@ -126,7 +146,7 @@
                     {% endfor %}
                 {% else %}
                     <tr>
-                        <td colspan="{{ 5 if can_manage_community else 3 }}" class="text-center text-muted py-4">
+                        <td colspan="{{ 6 if can_manage_community else 4 }}" class="text-center text-muted py-4">
                             No community members found.
                             {% if can_manage_community %}
                             <a href="{{ url_for('main.community_add') }}">Add one</a> or
@@ -139,11 +159,16 @@
             <tbody class="table-skeleton-body" aria-hidden="true">
                 {% for _ in range(5) %}
                 <tr>
+                    {% if can_manage_community %}
                     <td><span class="skeleton-block" style="width: 1rem;"></span></td>
+                    {% endif %}
                     <td><span class="skeleton-block w-75"></span></td>
                     <td><span class="skeleton-block w-50"></span></td>
                     <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    {% if can_manage_community %}
                     <td><span class="skeleton-block w-25"></span></td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </tbody>
@@ -152,11 +177,17 @@
     <div class="card-list d-lg-none">
         {% if members %}
             {% for member in members %}
+            {% set is_unsubscribed = member.phone in unsubscribed_phones %}
             <div class="card-list-item">
                 <div class="d-flex justify-content-between align-items-start gap-2">
                     <div>
                         <h6 class="mb-1">{{ member.name or '-' }}</h6>
                         <div class="text-muted small"><code>{{ member.phone }}</code></div>
+                        {% if is_unsubscribed %}
+                        <div class="text-muted small"><span class="badge bg-secondary">Unsubscribed</span></div>
+                        {% else %}
+                        <div class="text-muted small"><span class="badge bg-success">Active</span></div>
+                        {% endif %}
                         <div class="text-muted small">Added {{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</div>
                     </div>
                     {% if can_manage_community %}
@@ -174,6 +205,14 @@
                     <a href="{{ url_for('main.community_edit', member_id=member.id) }}" class="btn btn-sm btn-outline-secondary">
                         <i class="bi bi-pencil"></i> Edit
                     </a>
+                    {% if not is_unsubscribed %}
+                    <form method="POST" action="{{ url_for('main.community_unsubscribe', member_id=member.id) }}" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="btn btn-sm btn-outline-warning">
+                            <i class="bi bi-person-x"></i> Unsubscribe
+                        </button>
+                    </form>
+                    {% endif %}
                     <button type="button" class="btn btn-sm btn-outline-danger"
                             data-bs-toggle="modal" data-bs-target="#deleteModal"
                             data-member-name="{{ member.name }}" data-form-id="delete-member-{{ member.id }}">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -25,6 +25,9 @@
                             <div class="text-muted small">
                                 Community {{ community_count }} • Event registrations {{ event_registration_count }}
                             </div>
+                            <div class="text-muted small">
+                                Unsubscribed {{ unsubscribed_count }} (suppressed)
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/templates/events/detail.html
+++ b/app/templates/events/detail.html
@@ -14,6 +14,9 @@
 <a href="{{ url_for('main.event_edit', event_id=event.id) }}" class="btn btn-outline-primary">
     <i class="bi bi-pencil me-1"></i>Edit
 </a>
+<a href="{{ url_for('main.event_export_registrations', event_id=event.id) }}" class="btn btn-outline-secondary">
+    <i class="bi bi-download me-1"></i>Export CSV
+</a>
 <a href="{{ url_for('main.events_list') }}" class="btn btn-outline-secondary">
     <i class="bi bi-arrow-left me-1"></i>Back
 </a>
@@ -76,16 +79,33 @@
                         <tr>
                             <th>Name</th>
                             <th>Phone</th>
+                            <th>Status</th>
                             <th width="60"></th>
                         </tr>
                     </thead>
                     <tbody>
                         {% if registrations %}
                         {% for reg in registrations %}
+                        {% set is_unsubscribed = reg.phone in unsubscribed_phones %}
                         <tr>
                             <td>{{ reg.name or '-' }}</td>
                             <td><code>{{ reg.phone }}</code></td>
                             <td>
+                                {% if is_unsubscribed %}
+                                <span class="badge bg-secondary">Unsubscribed</span>
+                                {% else %}
+                                <span class="badge bg-success">Active</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if not is_unsubscribed %}
+                                <form method="POST" action="{{ url_for('main.event_registration_unsubscribe', event_id=event.id, registration_id=reg.id) }}" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-sm btn-outline-warning" title="Unsubscribe">
+                                        <i class="bi bi-person-x"></i>
+                                    </button>
+                                </form>
+                                {% endif %}
                                 <form method="POST" action="{{ url_for('main.event_unregister', event_id=event.id, registration_id=reg.id) }}" class="d-inline">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove" onclick="return confirm('Remove this registration?');">
@@ -97,7 +117,7 @@
                         {% endfor %}
                         {% else %}
                         <tr>
-                            <td colspan="3" class="text-center text-muted py-3">No registrations yet.</td>
+                            <td colspan="4" class="text-center text-muted py-3">No registrations yet.</td>
                         </tr>
                         {% endif %}
                     </tbody>

--- a/app/templates/unsubscribed/form.html
+++ b/app/templates/unsubscribed/form.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}Add Unsubscribed Contact - SMS Admin{% endblock %}
+
+{% block page_title %}Add Unsubscribed Contact{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.unsubscribed_list') }}">Unsubscribed</a> /
+<span>Add</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.unsubscribed_list') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left me-1"></i>Back
+</a>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card app-card">
+            <div class="card-body">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">Name (optional)</label>
+                        <input type="text" class="form-control" id="name" name="name" placeholder="Contact name">
+                    </div>
+                    <div class="mb-3">
+                        <label for="phone" class="form-label">Phone</label>
+                        <input type="tel" class="form-control" id="phone" name="phone" placeholder="+1 (555) 555-5555" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="source" class="form-label">Source</label>
+                        <input type="text" class="form-control" id="source" name="source" placeholder="manual" value="manual">
+                        <div class="form-text">Helps track why the number is suppressed (e.g., manual, event:123).</div>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Add Unsubscribed</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/unsubscribed/import.html
+++ b/app/templates/unsubscribed/import.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Import Unsubscribed - SMS Admin{% endblock %}
+
+{% block page_title %}Import Unsubscribed Contacts{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> /
+<a href="{{ url_for('main.unsubscribed_list') }}">Unsubscribed</a> /
+<span>Import CSV</span>
+{% endblock %}
+
+{% block page_actions %}
+<a href="{{ url_for('main.unsubscribed_list') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-arrow-left me-1"></i>Back
+</a>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card app-card">
+            <div class="card-body">
+                <form method="POST" enctype="multipart/form-data">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="file" class="form-label">Upload CSV</label>
+                        <input type="file" class="form-control" id="file" name="file" accept=".csv" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary w-100">Import CSV</button>
+                    <div class="form-text mt-2">Supports: phone only, name+phone, or first+last+phone.</div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/unsubscribed/list.html
+++ b/app/templates/unsubscribed/list.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+
+{% block title %}Unsubscribed Contacts - SMS Admin{% endblock %}
+
+{% block page_title %}Unsubscribed Contacts{% endblock %}
+
+{% set can_manage_unsubscribed = current_user.is_admin %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Unsubscribed</span>
+{% endblock %}
+
+{% block page_actions %}
+{% if can_manage_unsubscribed %}
+<a href="{{ url_for('main.unsubscribed_import') }}" class="btn btn-outline-primary">
+    <i class="bi bi-upload me-1"></i>Import CSV
+</a>
+<a href="{{ url_for('main.unsubscribed_export') }}" class="btn btn-outline-secondary">
+    <i class="bi bi-download me-1"></i>Export CSV
+</a>
+<a href="{{ url_for('main.unsubscribed_add') }}" class="btn btn-primary">
+    <i class="bi bi-plus-lg me-1"></i>Add Unsubscribed
+</a>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="card app-card mb-4">
+    <div class="card-body">
+        <form method="GET" class="filter-bar" data-table-loading-target="unsubscribedTable">
+            <div class="flex-grow-1">
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-search"></i></span>
+                    <input type="text" class="form-control" name="search" placeholder="Search by name, phone, or source..."
+                           value="{{ search }}">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-secondary">
+                <i class="bi bi-funnel me-1"></i>Apply
+            </button>
+        </form>
+    </div>
+</div>
+
+<div class="card app-card">
+    <div class="table-responsive">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="unsubscribedTable">
+            <thead class="table-light">
+                <tr>
+                    <th>Name</th>
+                    <th>Phone</th>
+                    <th>Source</th>
+                    <th>Added</th>
+                    {% if can_manage_unsubscribed %}
+                    <th width="80">Actions</th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody class="table-data">
+                {% if unsubscribed %}
+                    {% for entry in unsubscribed %}
+                    <tr>
+                        <td>{{ entry.name or '-' }}</td>
+                        <td><code>{{ entry.phone }}</code></td>
+                        <td><span class="badge bg-light text-dark">{{ entry.source }}</span></td>
+                        <td>{{ entry.created_at.strftime('%Y-%m-%d') if entry.created_at else '-' }}</td>
+                        {% if can_manage_unsubscribed %}
+                        <td>
+                            <form method="POST" action="{{ url_for('main.unsubscribed_delete', entry_id=entry.id) }}" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </form>
+                        </td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="{{ 5 if can_manage_unsubscribed else 4 }}" class="text-center text-muted py-4">
+                            No unsubscribed contacts found.
+                            {% if can_manage_unsubscribed %}
+                            <a href="{{ url_for('main.unsubscribed_add') }}">Add one</a> or
+                            <a href="{{ url_for('main.unsubscribed_import') }}">import from CSV</a>.
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endif %}
+            </tbody>
+            <tbody class="table-skeleton-body" aria-hidden="true">
+                {% for _ in range(5) %}
+                <tr>
+                    <td><span class="skeleton-block w-75"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    <td><span class="skeleton-block w-50"></span></td>
+                    {% if can_manage_unsubscribed %}
+                    <td><span class="skeleton-block w-25"></span></td>
+                    {% endif %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% if unsubscribed %}
+    <div class="card-footer text-muted">
+        Showing {{ unsubscribed|length }} contact(s)
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
### Motivation

- Provide a first-class opt-out (unsubscribed) list so the app can suppress messages to numbers that should not receive SMS.
- Ensure both immediate and scheduled sends respect unsubscribe state to avoid sending to opted-out contacts.
- Give admins the ability to manage unsubscribed numbers via UI and bulk CSV import/export to simplify operations.

### Description

- Added `UnsubscribedContact` model and a `recipient_service` helper with `filter_unsubscribed_recipients` and `get_unsubscribed_phone_set` to centralize suppression logic.
- Integrated suppression into manual sends in `dashboard` and into the scheduler in `app/services/scheduler_service.py` so unsubscribed numbers are skipped and logged/announced.
- Implemented unsubscribe management routes and templates (`/unsubscribed` list, add, import, export, delete) and added UI indicators (nav link, dashboard KPI, badges and unsubscribe actions in community/event lists).
- Added CSV export endpoints for community members and event registrations and wired export buttons into the templates.

### Testing

- Compiled the app Python modules with `python -m compileall app` which completed successfully.
- Started the development server (`SECRET_KEY=dev ADMIN_PASSWORD=admin FLASK_ENV=development flask --app wsgi:app run`) and exercised the UI with a headless Playwright script that logged in and captured the Unsubscribed page screenshot, which completed without errors.
- Confirmed templates render and new routes respond during the manual automated run; no runtime exceptions were observed during these checks.
- Note: no external Twilio calls were executed during testing (scheduler/send paths were exercised in test mode or with suppressed recipients).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7e5ee458832482ac5b1c816305e2)