### PR TITLE
Fix log selection count on responsive lists

### DIFF
--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -228,8 +228,18 @@
     const selectedCountEl = document.getElementById('selectedCount');
     const selectAllLogs = document.getElementById('selectAllLogs');
 
+    function isDesktopView() {
+        return window.matchMedia('(min-width: 992px)').matches;
+    }
+
     function getLogCheckboxes() {
-        return Array.from(document.querySelectorAll('.js-select-row'));
+        const container = isDesktopView()
+            ? document.querySelector('.table-responsive.d-lg-block')
+            : document.querySelector('.card-list.d-lg-none');
+        if (!container) {
+            return [];
+        }
+        return Array.from(container.querySelectorAll('.js-select-row'));
     }
 
     function updateBulkUi() {
@@ -239,8 +249,13 @@
         selectedCountEl.textContent = selected;
         bulkActionBar.classList.toggle('is-visible', selected > 0);
         if (selectAllLogs) {
-            selectAllLogs.checked = boxes.length > 0 && boxes.every(b => b.checked);
-            selectAllLogs.indeterminate = selected > 0 && selected < boxes.length;
+            if (isDesktopView()) {
+                selectAllLogs.checked = boxes.length > 0 && boxes.every(b => b.checked);
+                selectAllLogs.indeterminate = selected > 0 && selected < boxes.length;
+            } else {
+                selectAllLogs.checked = false;
+                selectAllLogs.indeterminate = false;
+            }
         }
     }
 
@@ -279,7 +294,10 @@
         });
     }
 
-    getLogCheckboxes().forEach(b => b.addEventListener('change', updateBulkUi));
+    window.addEventListener('resize', updateBulkUi);
+
+    Array.from(document.querySelectorAll('.js-select-row'))
+        .forEach(b => b.addEventListener('change', updateBulkUi));
     updateBulkUi();
 </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Prevent double-counting selections caused by having both a desktop table and a mobile card-list in the DOM at the same time.
- Ensure the `Select all` checkbox only reflects the desktop table where it exists visually.
- Keep bulk-selection UI correct when the viewport changes between mobile and desktop layouts.

### Description
- Restrict checkbox queries to the currently visible container by adding `isDesktopView()` and scoping `getLogCheckboxes()` to `.table-responsive.d-lg-block` or `.card-list.d-lg-none` in `app/templates/logs/list.html`.
- Make the `selectAllLogs` state update only for desktop view and clear its state on mobile view to avoid applying desktop selection to the hidden mobile list.
- Recompute selection totals on window `resize` via `window.addEventListener('resize', updateBulkUi);`.
- Attach change listeners to all `.js-select-row` checkboxes and keep bulk UI updates in `updateBulkUi()`.

### Testing
- Installed dependencies with `python -m pip install -r requirements.txt` and the install completed successfully.
- Seeded the database with test `MessageLog` entries via a small Python script and the seeding succeeded.
- Launched the dev server with `flask --app wsgi:app run` and the server started successfully.
- Attempted an automated Playwright UI capture to verify behavior, but the Chromium binary crashed and the Playwright check failed (environment/browser issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e835b8f2c832480e5f43a7237e764)