### PR TITLE
Add RQ background pipeline for SMS sending

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,10 @@ class Config:
     SCHEDULER_ENABLED = os.environ.get('SCHEDULER_ENABLED', '1' if DEBUG else '0') == '1'
 
     APP_TIMEZONE = os.environ.get('APP_TIMEZONE', 'UTC')
+
+    # Redis / RQ
+    REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+    RQ_QUEUE_NAME = os.environ.get('RQ_QUEUE_NAME', 'sms')
     
     # Database
     BASE_DIR = Path(__file__).resolve().parent.parent

--- a/app/models.py
+++ b/app/models.py
@@ -105,6 +105,7 @@ class MessageLog(db.Model):
     message_body = db.Column(db.Text, nullable=False)
     target = db.Column(db.String(20), nullable=False)  # 'community' or 'event'
     event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable=True)
+    status = db.Column(db.String(20), default='sent')  # 'processing', 'sent', 'failed'
     total_recipients = db.Column(db.Integer, default=0)
     success_count = db.Column(db.Integer, default=0)
     failure_count = db.Column(db.Integer, default=0)

--- a/app/queue.py
+++ b/app/queue.py
@@ -1,0 +1,18 @@
+from redis import Redis
+from rq import Queue
+
+
+def get_redis_connection(app=None):
+    if app is None:
+        from flask import current_app
+        app = current_app
+    redis_url = app.config.get('REDIS_URL', 'redis://localhost:6379/0')
+    return Redis.from_url(redis_url)
+
+
+def get_queue(app=None):
+    if app is None:
+        from flask import current_app
+        app = current_app
+    queue_name = app.config.get('RQ_QUEUE_NAME', 'sms')
+    return Queue(queue_name, connection=get_redis_connection(app))

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,40 @@
+import json
+from rq import get_current_job
+from app import create_app, db
+from app.models import MessageLog
+from app.services.twilio_service import TwilioTransientError, get_twilio_service
+
+
+def _should_mark_failed() -> bool:
+    job = get_current_job()
+    if job is None:
+        return True
+    return job.retries_left == 0
+
+
+def send_bulk_job(log_id: int, recipient_data: list, final_message: str, delay: float = 0.1) -> None:
+    app = create_app()
+    with app.app_context():
+        log = MessageLog.query.get(log_id)
+        if not log:
+            raise ValueError(f"MessageLog {log_id} not found")
+
+        try:
+            twilio = get_twilio_service()
+            result = twilio.send_bulk(recipient_data, final_message, delay=delay, raise_on_transient=True)
+            log.total_recipients = result['total']
+            log.success_count = result['success_count']
+            log.failure_count = result['failure_count']
+            log.details = json.dumps(result['details'])
+            log.status = 'sent' if result['failure_count'] == 0 else 'failed'
+            db.session.commit()
+        except TwilioTransientError as exc:
+            if _should_mark_failed():
+                log.status = 'failed'
+                log.details = json.dumps([{'error': str(exc)}])
+                db.session.commit()
+            raise
+        except Exception as exc:
+            log.status = 'failed'
+            log.details = json.dumps([{'error': str(exc)}])
+            db.session.commit()

--- a/app/templates/logs/detail.html
+++ b/app/templates/logs/detail.html
@@ -40,6 +40,13 @@
                     
                     <dt>Total Recipients</dt>
                     <dd>{{ log.total_recipients }}</dd>
+
+                    <dt>Status</dt>
+                    <dd>
+                        <span class="badge bg-{% if log.status == 'processing' %}warning{% elif log.status == 'failed' %}danger{% else %}success{% endif %}">
+                            {{ log.status or 'sent' }}
+                        </span>
+                    </dd>
                     
                     <dt>Results</dt>
                     <dd>

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -93,6 +93,11 @@
                         </span>
                     </td>
                     <td>
+                        <div class="mb-1">
+                            <span class="badge bg-{% if log.status == 'processing' %}warning{% elif log.status == 'failed' %}danger{% else %}success{% endif %}">
+                                {{ log.status or 'sent' }}
+                            </span>
+                        </div>
                         <span class="text-success">{{ log.success_count }} sent</span>
                         {% if log.failure_count > 0 %}
                         / <span class="text-danger">{{ log.failure_count }} failed</span>
@@ -144,6 +149,11 @@
                         <div class="text-muted small">
                             {{ log.target }}{% if log.event %} · {{ log.event.title }}{% endif %}
                         </div>
+                        <div class="mt-1">
+                            <span class="badge bg-{% if log.status == 'processing' %}warning{% elif log.status == 'failed' %}danger{% else %}success{% endif %}">
+                                {{ log.status or 'sent' }}
+                            </span>
+                        </div>
                         <div class="text-muted small">{{ log.message_body[:50] }}{% if log.message_body|length > 50 %}...{% endif %}</div>
                     </div>
                     <input class="form-check-input js-select-row" type="checkbox" aria-label="Select log">
@@ -182,6 +192,7 @@
         </div>
         <div class="offcanvas-body">
             <p class="mb-2"><strong>Target:</strong> {{ log.target }}</p>
+            <p class="mb-2"><strong>Status:</strong> {{ log.status or 'sent' }}</p>
             <p class="mb-2"><strong>Sent:</strong> {{ log.success_count }} success / {{ log.failure_count }} failed</p>
             <p class="mb-0"><strong>Message:</strong> {{ log.message_body }}</p>
         </div>

--- a/deploy/sms-worker.service
+++ b/deploy/sms-worker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SMS Admin RQ Worker
+After=network.target redis.service
+
+[Service]
+User=smsadmin
+Group=smsadmin
+WorkingDirectory=/opt/sms-admin
+Environment="PATH=/opt/sms-admin/venv/bin"
+Environment="SCHEDULER_ENABLED=0"
+Environment="RQ_QUEUE_NAME=sms"
+EnvironmentFile=/opt/sms-admin/.env
+ExecStart=/opt/sms-admin/venv/bin/rq worker --url ${REDIS_URL} ${RQ_QUEUE_NAME}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ python-dotenv==1.0.0
 gunicorn==21.2.0
 Werkzeug==3.0.1
 APScheduler==3.10.4
+redis==5.0.1
+rq==1.15.1


### PR DESCRIPTION
### Motivation
- Offload long-running SMS blasts from the web request to a background worker so HTTP responses return immediately. 
- Persist a message log in a `processing` state before sending so there is an auditable record even if sending fails. 
- Add transient-error-aware retry behavior for Twilio API errors to improve reliability. 
- Expose message `status` in the logs UI so users can see `processing` / `sent` / `failed` states.

### Description
- Added a `status` column to `MessageLog` and write a `processing` record before enqueueing sends (`app/models.py`).
- Introduced RQ-based queue helpers in `app/queue.py`, a worker task `send_bulk_job` in `app/tasks.py`, and a systemd unit file `deploy/sms-worker.service` to run the worker. 
- Switched dashboard sends to enqueue `app.tasks.send_bulk_job` with a retry policy and updated `app/routes.py` to commit the initial log and return immediately. 
- Made `TwilioService` detect transient Twilio errors and raise `TwilioTransientError` so the worker can retry; updated templates to surface `log.status` and added `redis` / `rq` to `requirements.txt`.

### Testing
- No automated unit/CI tests were run as part of this change. 
- Commands executed during the change: `git status`, `git add`, `git commit`, and a small Playwright script was run to attempt a screenshot of the `/logs` page (the app server was not running in this environment so the screenshot did not render a live page). 
- Creating the migrations / production DB schema update is required after deploying (the `MessageLog.status` column was added to the model and needs to be applied to the DB before use).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8b61d4b483249858a82d6a612da0)