### PR TITLE
Update AGENTS ops guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,12 @@ This repository welcomes AI agents. Use this guide to work safely, predictably, 
 - [ ] Tests or checks run (or skipped with reason).
 - [ ] Summary is concise and accurate.
 - [ ] No hidden side effects.
+
+## 9) Quick ops guide (Codex)
+- **Unit tests:** run `pytest`. If none exist, add focused tests in `tests/` and document how to run them.
+- **DB doctor & migrations:** run `python app/dbdoctor.py` and `python app/migrate.py` (apply migrations before serving).
+- **Systemd services:** expected units are `sms` and `sms-scheduler`; both should load environment from the systemd EnvironmentFile or `/etc/default/sms` before start.
+- **Definition of done (prod):**
+  - [ ] No 500s in logs after deploy.
+  - [ ] Migrations run **before** serving traffic.
+  - [ ] Logs are clear of errors for `sms` and `sms-scheduler`.


### PR DESCRIPTION
### Motivation
- Provide a short, actionable ops guide in the top-level `AGENTS.md` so agents know how to run tests, migrations, and validate services.
- Make expected runtime details explicit by documenting the `sms` and `sms-scheduler` systemd units and environment loading conventions.
- Add a brief production definition-of-done to reduce deployment regressions such as 500s and missed migrations.

### Description
- Added a new "Quick ops guide (Codex)" section to `AGENTS.md` with instructions for running unit tests via `pytest`.
- Documented how to run DB checks and migrations with `python app/dbdoctor.py` and `python app/migrate.py` and noted to apply migrations before serving.
- Specified expected systemd service names (`sms` and `sms-scheduler`) and that they should load environment from an EnvironmentFile or `/etc/default/sms`.
- Added a short production checklist including no 500s in logs, migrations run before traffic, and clear logs for `sms` and `sms-scheduler`.

### Testing
- No automated tests were run because this is a documentation-only change.
- Commands executed while preparing the change included `ls`, `cat AGENTS.md`, `nl -ba AGENTS.md`, `git add AGENTS.md`, and `git commit -m "Update ops guidance in AGENTS"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea06b34b88324856608bee9bbad47)