### PR TITLE
Run dbdoctor without Flask init to avoid SECRET_KEY dependency

### DIFF
--- a/tests/test_dbdoctor.py
+++ b/tests/test_dbdoctor.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class TestDbDoctor(unittest.TestCase):
+    def test_dbdoctor_without_secret_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = os.path.join(temp_dir, "sms.db")
+            env = os.environ.copy()
+            env.pop("SECRET_KEY", None)
+            env["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+            result = subprocess.run(
+                [sys.executable, "-m", "app.dbdoctor", "--print"],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Database file:", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure `app.dbdoctor` can be executed in a clean shell without sourcing `.env` and without failing due to `SECRET_KEY` checks in `create_app`.
- Make `dbdoctor` report the absolute database path and migration state independent of Flask app initialization.
- Allow migrations to be applied safely from a standalone context without starting the Flask app or scheduler.

### Description
- Replace Flask app initialization in `app/dbdoctor.py` with a standalone SQLAlchemy engine built from `Config.SQLALCHEMY_DATABASE_URI` and `Config.SQLALCHEMY_ENGINE_OPTIONS` using `create_engine`.
- Create schema metadata with `db.metadata.create_all(bind=engine)` before running `run_pending_migrations(engine, logger)` so migrations can be applied without `app` context.
- Keep migration inspection via `inspect_migrations(engine)` and print the resolved DB path and per-version status with `_print_report`.
- Add `tests/test_dbdoctor.py` which invokes `python -m app.dbdoctor --print` in a subprocess with `SECRET_KEY` removed and `DATABASE_URL` set to a temp SQLite file, and asserts exit code 0 and presence of "Database file:" in output.

### Testing
- Ran `pytest -q` to execute the test suite. 
- The test added (`tests/test_dbdoctor.py`) invokes `python -m app.dbdoctor --print` (as part of the subprocess call in the test).
- Automated test run failed during collection with `ModuleNotFoundError: No module named 'app'` so the new test did not execute to completion. 
- Commands run during the rollout include `pytest -q`, `nl -ba app/dbdoctor.py`, and `git commit -m "Refactor dbdoctor to avoid app initialization"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea12481f8832482b10d3316daedd8)