### PR TITLE
Log scheduler startup mode; prevent duplicate init; add web-mode scheduler test

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,11 +75,24 @@ def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] =
                     db.session.commit()
     
     # Start background scheduler
+    scheduler_setting = app.config.get('SCHEDULER_ENABLED')
+    scheduler_reason = "explicit override" if start_scheduler is not None else "configuration"
     if start_scheduler is None:
-        start_scheduler = app.config.get('SCHEDULER_ENABLED')
+        start_scheduler = scheduler_setting
 
     if start_scheduler:
+        app.logger.info(
+            "Scheduler enabled (SCHEDULER_ENABLED=%s) via %s; starting background scheduler.",
+            scheduler_setting,
+            scheduler_reason,
+        )
         from app.services.scheduler_service import init_scheduler
         init_scheduler(app)
+    else:
+        app.logger.info(
+            "Scheduler disabled (SCHEDULER_ENABLED=%s) via %s; running web app only.",
+            scheduler_setting,
+            scheduler_reason,
+        )
     
     return app

--- a/app/services/scheduler_service.py
+++ b/app/services/scheduler_service.py
@@ -130,6 +130,7 @@ def init_scheduler(app):
     global scheduler, _scheduler_initialized
     
     if _scheduler_initialized:
+        app.logger.warning("Scheduler already initialized; skipping duplicate startup.")
         return
     
     _scheduler_initialized = True
@@ -146,7 +147,7 @@ def init_scheduler(app):
     
     scheduler.start()
     atexit.register(lambda: scheduler.shutdown() if scheduler and scheduler.running else None)
-    print("[Scheduler] Background scheduler started")
+    app.logger.info("[Scheduler] Background scheduler started")
 
 
 def shutdown_scheduler():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)

--- a/tests/test_scheduler_mode.py
+++ b/tests/test_scheduler_mode.py
@@ -1,0 +1,42 @@
+"""Tests for scheduler startup mode.
+
+Run with: python -m unittest tests.test_scheduler_mode
+"""
+
+import os
+import unittest
+
+from app import create_app
+from app.services import scheduler_service
+
+
+class TestSchedulerMode(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_scheduler_enabled = os.environ.get("SCHEDULER_ENABLED")
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["SCHEDULER_ENABLED"] = "0"
+        os.environ["FLASK_DEBUG"] = "1"
+        scheduler_service._scheduler_initialized = False
+        scheduler_service.scheduler = None
+
+    def tearDown(self) -> None:
+        scheduler_service.shutdown_scheduler()
+        scheduler_service._scheduler_initialized = False
+        scheduler_service.scheduler = None
+        if self._original_scheduler_enabled is None:
+            os.environ.pop("SCHEDULER_ENABLED", None)
+        else:
+            os.environ["SCHEDULER_ENABLED"] = self._original_scheduler_enabled
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+
+    def test_web_app_mode_does_not_start_scheduler(self) -> None:
+        create_app(run_startup_tasks=False)
+        self.assertFalse(scheduler_service._scheduler_initialized)
+        self.assertIsNone(scheduler_service.scheduler)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure the web service (`sms.service`) does not start scheduler threads when `SCHEDULER_ENABLED=0` and the scheduler service (`sms-scheduler.service`) can be run independently with `SCHEDULER_ENABLED=1`.
- Make startup behavior explicit in logs so operators can see whether the scheduler is enabled and why (config vs explicit override).
- Avoid accidental double-initialization of the background scheduler in multi-start scenarios.
- Provide a regression test that validates the web-only mode does not start the scheduler.

### Description
- Add explicit decision logging in `create_app` to record `SCHEDULER_ENABLED` and whether the decision came from configuration or an explicit `start_scheduler` override (`app/__init__.py`).
- Add a duplicate-initialization guard warning and replace a `print` with `app.logger.info` when the scheduler starts (`app/services/scheduler_service.py`).
- Add a test helper `tests/conftest.py` to ensure the repo root is on `sys.path` for test collection.
- Add `tests/test_scheduler_mode.py` which forces `SCHEDULER_ENABLED=0` and `FLASK_DEBUG=1` and asserts the scheduler is not initialized by `create_app`.

### Testing
- Ran the full test suite with `pytest` and all tests passed: `13 passed`.
- The new test `tests/test_scheduler_mode.py` was executed as part of the suite and verified web-app mode does not initialize the scheduler.
- No manual systemd or external integrations were modified or tested; only unit tests were executed with the repository test harness (`pytest`).
- If additional runtime verification is required in deployment (systemd units `sms` vs `sms-scheduler`), add integration checks in CI or staging before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea4443f2c83249134f9e6ca11c287)