### PR TITLE
Add dbdoctor regression test for message_logs

### DIFF
--- a/tests/test_dbdoctor.py
+++ b/tests/test_dbdoctor.py
@@ -1,11 +1,38 @@
+import importlib
 import os
+import sqlite3
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import contextmanager
 
 
 class TestDbDoctor(unittest.TestCase):
+    @contextmanager
+    def _temporary_env(self, updates: dict[str, str]) -> None:
+        original = os.environ.copy()
+        os.environ.update(updates)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
+    def _create_legacy_message_logs_db(self, db_path: str) -> None:
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE message_logs (
+                    id INTEGER PRIMARY KEY,
+                    created_at TEXT,
+                    message_body TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    event_id INTEGER
+                )
+                """
+            )
+
     def test_dbdoctor_without_secret_key(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             db_path = os.path.join(temp_dir, "sms.db")
@@ -22,6 +49,55 @@ class TestDbDoctor(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Database file:", result.stdout)
+
+    def test_dbdoctor_applies_message_logs_columns(self) -> None:
+        from sqlalchemy.exc import OperationalError
+
+        expected_columns = {
+            "status",
+            "total_recipients",
+            "success_count",
+            "failure_count",
+            "details",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = os.path.join(temp_dir, "sms.db")
+            self._create_legacy_message_logs_db(db_path)
+            env = os.environ.copy()
+            env["DATABASE_URL"] = f"sqlite:///{db_path}"
+            env["SECRET_KEY"] = "test-secret"
+            env["FLASK_DEBUG"] = "1"
+
+            result = subprocess.run(
+                [sys.executable, "-m", "app.dbdoctor", "--apply"],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            with sqlite3.connect(db_path) as connection:
+                columns = {
+                    row[1] for row in connection.execute("PRAGMA table_info(message_logs)")
+                }
+
+            self.assertTrue(expected_columns.issubset(columns))
+
+            with self._temporary_env(env):
+                import app.config
+
+                importlib.reload(app.config)
+                from app import create_app
+                from app.models import MessageLog
+
+                app = create_app(run_startup_tasks=False, start_scheduler=False)
+                with app.app_context():
+                    try:
+                        MessageLog.query.order_by(MessageLog.created_at.desc()).limit(5).all()
+                    except OperationalError as exc:
+                        self.fail(f"MessageLog query raised OperationalError after migration: {exc}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure the migration that adds new columns to `message_logs` is applied to legacy SQLite databases and does not leave the web routes failing with `OperationalError`.
- Prevent regressions where the dashboard/logs code would raise due to missing `message_logs` columns after an upgrade.
- Provide a deterministic CI test that simulates an older schema and verifies upgrade behavior.

### Description
- Updated `tests/test_dbdoctor.py` to add `_create_legacy_message_logs_db` and `_temporary_env` helpers and a new test `test_dbdoctor_applies_message_logs_columns` that creates an old `message_logs` table schema and runs `python -m app.dbdoctor --apply` via `subprocess`.
- The test asserts the expected columns (`status`, `total_recipients`, `success_count`, `failure_count`, `details`) are present after migration by querying `PRAGMA table_info(message_logs)` with `sqlite3`.
- The test also reloads config and initializes the app with `create_app(run_startup_tasks=False, start_scheduler=False)` and runs a `MessageLog` query to ensure no `OperationalError` is raised by the dashboard/logs code.
- Test behavior is deterministic and uses `tempfile.TemporaryDirectory()` plus explicit `DATABASE_URL`, `SECRET_KEY`, and `FLASK_DEBUG` environment variables.

### Testing
- Ran `pytest tests/test_dbdoctor.py` which executed the new regression test and the existing test, and resulted in `2 passed`.
- The test runs `python -m app.dbdoctor --apply` as a subprocess and validated migration application and query behavior without errors.
- The approach is CI-friendly and deterministic because it uses an isolated temporary SQLite file and controlled environment variables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea5878068832493230dc97fa01074)