### PR TITLE
Reload app.config after temporary env restores

### DIFF
--- a/tests/test_dbdoctor.py
+++ b/tests/test_dbdoctor.py
@@ -18,6 +18,10 @@ class TestDbDoctor(unittest.TestCase):
         finally:
             os.environ.clear()
             os.environ.update(original)
+            if "app.config" in sys.modules:
+                import app.config
+
+                importlib.reload(app.config)
 
     def _create_legacy_message_logs_db(self, db_path: str) -> None:
         with sqlite3.connect(db_path) as connection:


### PR DESCRIPTION
### Motivation
- Temporary environment overrides in tests can leave module-level `Config` values (from `app.config`) pointing at transient resources like a temp `DATABASE_URL` or `FLASK_DEBUG` setting.
- Because `Config` reads environment at import time, restoring `os.environ` alone does not update the already-imported `app.config` module.
- This can cause later tests that call `create_app` to operate against removed temp directories or unexpectedly start the scheduler, producing cross-test failures.

### Description
- Update the test helper in `tests/test_dbdoctor.py` to reload `app.config` after restoring the original environment by checking `if "app.config" in sys.modules` and calling `importlib.reload(app.config)`.
- The change is scoped to tests and does not modify production code or behavior.

### Testing
- No automated test suite was run as part of this change.
- The modification is a targeted, small test-only fix intended to prevent cross-test state leakage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eac55c7888324854771021c718d78)