### PR TITLE
Rollback session after MessageLog OperationalError in dashboard

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,6 +58,7 @@ def dashboard():
             recent_logs = MessageLog.query.order_by(MessageLog.created_at.desc()).limit(5).all()
         except OperationalError as exc:
             from flask import current_app
+            db.session.rollback()
             current_app.logger.warning(
                 'MessageLog query failed due to schema mismatch: %s',
                 exc,


### PR DESCRIPTION
### Motivation
- Avoid a `PendingRollbackError` and 500 on `/dashboard` when `MessageLog` queries raise `OperationalError` by ensuring the SQLAlchemy session is reset.
- Ensure subsequent queries in the dashboard context (such as `ScheduledMessage.query.filter_by(...).count()`) can run after a `MessageLog` schema-related failure.

### Description
- Add `db.session.rollback()` inside the `except OperationalError` handler in `build_dashboard_context` to reset the session after `MessageLog` query failures.
- The change was made in `app/routes.py` near the `MessageLog` queries.
- Commands executed during the change include `rg` to locate references, `sed`/`nl` to inspect file sections, `apply_patch` to modify the file, and `git add` / `git commit` to record the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eac6f0b648324bf01c840ce245b93)