### PR TITLE
Treat non-SQLite migrations as applied in inspection

### DIFF
--- a/app/migrations/runner.py
+++ b/app/migrations/runner.py
@@ -89,10 +89,11 @@ def _sqlite_db_path(engine: Engine) -> str:
 
 def inspect_migrations(engine: Engine) -> dict[str, list[str] | str]:
     migrations = _migration_files()
-    applied: list[str] = []
     if engine.url.drivername.startswith("sqlite"):
         with engine.connect() as connection:
             applied = sorted(_get_applied_versions(connection))
+    else:
+        applied = [migration.version for migration in migrations]
     return {
         "db_path": _sqlite_db_path(engine),
         "migrations": [migration.version for migration in migrations],


### PR DESCRIPTION
### Motivation
- The SQLite-only inspection returned an empty `applied` list for non-SQLite engines, which made all migrations appear pending.
- That produced false pending migration reports in `app/dbdoctor.py` and startup logs for Postgres/MySQL deployments.
- The migration runner already skips applying SQLite migrations for non-SQLite databases, so inspection should reflect that behavior.
- Make a minimal change to avoid noisy/incorrect migration status without changing runtime migration behavior.

### Description
- Update `inspect_migrations` in `app/migrations/runner.py` to set `applied` to the list of all migration versions when `engine.url.drivername` does not start with `sqlite`.
- Retain the existing SQLite path that queries `_get_applied_versions` when the engine is SQLite.
- Leave `run_pending_migrations` behavior unchanged (it still no-ops for non-SQLite engines).
- Only `app/migrations/runner.py` was modified and the return shape of the inspection result remains the same.

### Testing
- No automated tests were run for this change.
- (No automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb1b658f48324836def10596957bf)