### PR TITLE
Disable login banner and fix Logs nav highlighting

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -7,7 +7,7 @@ from app.models import AppUser
 
 login_manager = LoginManager()
 login_manager.login_view = 'auth.login'
-login_manager.login_message = 'Please log in to access this page.'
+login_manager.login_message = None
 login_manager.login_message_category = 'warning'
 
 bp = Blueprint('auth', __name__)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,6 +9,7 @@
     <link href="{{ url_for('static', filename='css/app.css', v=app_version) }}" rel="stylesheet">
 </head>
 <body class="app-body">
+    {% set logs_active = request.endpoint and request.endpoint.startswith('main.logs') %}
     <div class="app-shell">
         <aside class="app-sidebar d-none d-lg-flex flex-column">
             <a class="app-sidebar-brand" href="{{ url_for('main.dashboard') }}">
@@ -38,7 +39,7 @@
                 <a class="app-nav-link {% if 'scheduled' in request.endpoint %}active{% endif %}" href="{{ url_for('main.scheduled_list') }}">
                     <i class="bi bi-clock me-2"></i>Scheduled
                 </a>
-                <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
+                <a class="app-nav-link {% if logs_active %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
                     <i class="bi bi-journal-text me-2"></i>Logs
                 </a>
                 {% if current_user.is_authenticated and current_user.is_admin %}
@@ -90,7 +91,7 @@
                             <a class="app-nav-link {% if 'scheduled' in request.endpoint %}active{% endif %}" href="{{ url_for('main.scheduled_list') }}">
                                 <i class="bi bi-clock me-2"></i>Scheduled
                             </a>
-                            <a class="app-nav-link {% if 'log' in request.endpoint %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
+                            <a class="app-nav-link {% if logs_active %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
                                 <i class="bi bi-journal-text me-2"></i>Logs
                             </a>
                             {% if current_user.is_authenticated and current_user.is_admin %}


### PR DESCRIPTION
### Motivation
- First-time visitors were seeing the Flask-Login unauthorized flash message and the Logs sidebar item was being highlighted incorrectly when arriving at the login page.
- The intent is to avoid showing an unnecessary "please log in" banner on the login screen and prevent the Logs nav from appearing selected unless actually on a logs route.

### Description
- Set `login_manager.login_message = None` in `app/auth.py` to disable the default unauthorized flash message.
- Compute `logs_active` in `app/templates/base.html` using `request.endpoint.startswith('main.logs')` and use it for both desktop and mobile nav entries so Logs is only highlighted on logs routes.
- Changes are minimal and follow existing template and authentication patterns.

### Testing
- No automated tests were run against the modified code.
- Commands used during investigation included `rg -n "login|signin|sign in|auth|Logs" app`, `sed -n '1,200p' app/auth.py`, and `sed -n '1,200p' app/templates/base.html`.
- Runtime verification (starting the app) and unit tests were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f100adc348324b1755af71905eba2)