### PR TITLE
Add auth layout without navigation (auth/base.html)

### DIFF
--- a/app/templates/auth/base.html
+++ b/app/templates/auth/base.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}SMS Admin{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/app.css', v=app_version) }}" rel="stylesheet">
+</head>
+<body class="app-body">
+    <div class="app-shell">
+        <div class="app-main w-100">
+            <main class="app-content container">
+                <header class="app-page-header">
+                    <div>
+                        <div class="app-breadcrumbs">
+                            {% block breadcrumbs %}{% endblock %}
+                        </div>
+                        <h1 class="app-page-title">
+                            {% block page_title %}SMS Admin{% endblock %}
+                        </h1>
+                    </div>
+                    <div class="app-page-actions">
+                        {% block page_actions %}{% endblock %}
+                    </div>
+                </header>
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                        <div class="app-toast-container">
+                            {% for category, message in messages %}
+                                {% if category == 'success' %}
+                                    <div class="toast app-toast text-bg-success border-0 mb-2" role="status" aria-live="polite" aria-atomic="true">
+                                        <div class="d-flex">
+                                            <div class="toast-body">
+                                                <i class="bi bi-check-circle me-2"></i>{{ message }}
+                                            </div>
+                                            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% for category, message in messages %}
+                            {% if category != 'success' %}
+                            <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert" aria-live="{{ 'assertive' if category == 'error' else 'polite' }}" aria-atomic="true">
+                                {{ message }}
+                                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                            </div>
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+                {% endwith %}
+
+                {% block content %}{% endblock %}
+            </main>
+
+            <footer class="app-footer text-center text-muted">
+                <small>AOC SMS &copy; 2025 - All rights reserved</small>
+            </footer>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const toastEls = document.querySelectorAll('.app-toast');
+        toastEls.forEach((toastEl) => {
+            const toast = new bootstrap.Toast(toastEl);
+            toast.show();
+        });
+
+        const tableLoadingForms = document.querySelectorAll('form[data-table-loading-target]');
+        tableLoadingForms.forEach((form) => {
+            form.addEventListener('submit', () => {
+                const targetIds = form.dataset.tableLoadingTarget || '';
+                targetIds.split(',').map((id) => id.trim()).filter(Boolean).forEach((id) => {
+                    const target = document.getElementById(id);
+                    if (target) {
+                        target.classList.add('is-loading');
+                    }
+                });
+            });
+        });
+    </script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "auth/base.html" %}
 
 {% block title %}Login - SMS Admin{% endblock %}
 


### PR DESCRIPTION
### Motivation
- Provide a minimal layout for unauthenticated/auth pages so login screens do not render the app sidebar or mobile navigation.
- Keep shared head, footer, flash handling and scripts in a single place to avoid duplicating markup across auth views.
- Preserve the existing authenticated app layout and navigation for logged-in users.

### Description
- Add `app/templates/auth/base.html` which includes the shared `<head>`, flash message handling, main content container and footer but omits the `<aside class="app-sidebar">` and mobile nav markup.
- Update `app/templates/auth/login.html` to extend `auth/base.html` instead of `base.html` so the login page renders without app chrome.
- Preserve existing template blocks (`content`, `page_title`, `scripts`, etc.) to remain compatible with other auth pages.

### Testing
- No automated tests were run for this change.
- Commands executed during the rollout included `ls`, `sed -n ...`, creating the file with `cat > app/templates/auth/base.html`, `git add`, and `git commit`.
- Files were inspected with `nl` to verify the new `auth/base.html` content and that `app/templates/auth/login.html` now extends `auth/base.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1253e7b483249a03af836d005a67)