### PR TITLE
Require password change on first login (must_change_password)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -86,6 +86,22 @@ def require_roles(*roles):
     return decorator
 
 
+@bp.before_app_request
+def enforce_password_change():
+    if not current_user.is_authenticated:
+        return None
+    if not current_user.must_change_password:
+        return None
+
+    endpoint = request.endpoint or ""
+    if endpoint.startswith("static"):
+        return None
+    if endpoint in {"auth.login", "auth.logout", "main.change_password"}:
+        return None
+
+    return redirect(url_for("main.change_password"))
+
+
 @login_manager.user_loader
 def load_user(user_id):
     """Load user by ID."""
@@ -110,6 +126,8 @@ def login():
         if user and user.check_password(password):
             login_user(user, remember=remember)
             _FAILED_LOGINS.pop(_get_client_ip(), None)
+            if user.must_change_password:
+                return redirect(url_for('main.change_password'))
             next_page = request.args.get('next')
             if next_page and _is_safe_url(next_page):
                 return redirect(next_page)

--- a/app/migrations/002_add_users_must_change_password.py
+++ b/app/migrations/002_add_users_must_change_password.py
@@ -1,0 +1,27 @@
+from sqlalchemy import text
+
+
+def apply(connection, logger) -> None:
+    result = connection.execute(text("PRAGMA table_info(users)"))
+    columns = {row._mapping["name"] for row in result}
+
+    if not columns:
+        logger.info("Skipping migration 002_add_users_must_change_password: table users does not exist.")
+        return
+
+    if "must_change_password" not in columns:
+        connection.execute(
+            text(
+                "ALTER TABLE users ADD COLUMN must_change_password INTEGER NOT NULL DEFAULT 0"
+            )
+        )
+        logger.info(
+            "Migration 002_add_users_must_change_password: added missing column 'must_change_password'."
+        )
+
+    connection.execute(
+        text("UPDATE users SET must_change_password = 0 WHERE must_change_password IS NULL")
+    )
+    logger.info(
+        "Migration 002_add_users_must_change_password: backfilled must_change_password to false."
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,7 @@ class AppUser(UserMixin, db.Model):
     username = db.Column(db.String(80), nullable=False, unique=True)
     password_hash = db.Column(db.String(255), nullable=False)
     role = db.Column(db.String(30), nullable=False, default='admin')
+    must_change_password = db.Column(db.Boolean, default=False, nullable=False)
     created_at = db.Column(db.DateTime, default=utc_now)
 
     def set_password(self, password: str) -> None:

--- a/app/templates/auth/change_password.html
+++ b/app/templates/auth/change_password.html
@@ -1,0 +1,46 @@
+{% extends "auth/base.html" %}
+
+{% block title %}Change Password - SMS Admin{% endblock %}
+
+{% block page_title %}Change Password{% endblock %}
+
+{% block breadcrumbs %}
+<span>Change Password</span>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card app-card">
+            <div class="card-header">
+                <h5 class="mb-0">
+                    <i class="bi bi-shield-lock me-2"></i>Update your password
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-3">
+                        <label for="current_password" class="form-label">Current password <span class="text-danger">*</span></label>
+                        <input type="password" class="form-control" id="current_password" name="current_password" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="new_password" class="form-label">New password <span class="text-danger">*</span></label>
+                        <input type="password" class="form-control" id="new_password" name="new_password" required>
+                    </div>
+                    <div class="mb-4">
+                        <label for="confirm_password" class="form-label">Confirm new password <span class="text-danger">*</span></label>
+                        <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-check-lg me-1"></i>Update password
+                        </button>
+                        <a href="{{ url_for('main.dashboard') }}" class="btn btn-outline-secondary">Cancel</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -50,6 +50,9 @@
             </nav>
             {% if current_user.is_authenticated %}
             <div class="mt-auto">
+                <a class="app-nav-link" href="{{ url_for('main.change_password') }}">
+                    <i class="bi bi-key me-2"></i>Change Password
+                </a>
                 <a class="app-nav-link" href="{{ url_for('auth.logout') }}">
                     <i class="bi bi-box-arrow-right me-2"></i>Logout
                 </a>
@@ -100,6 +103,9 @@
                             </a>
                             {% endif %}
                             {% if current_user.is_authenticated %}
+                            <a class="app-nav-link mt-2" href="{{ url_for('main.change_password') }}">
+                                <i class="bi bi-key me-2"></i>Change Password
+                            </a>
                             <a class="app-nav-link mt-2" href="{{ url_for('auth.logout') }}">
                                 <i class="bi bi-box-arrow-right me-2"></i>Logout
                             </a>

--- a/app/templates/users/form.html
+++ b/app/templates/users/form.html
@@ -48,6 +48,14 @@
                         {% endif %}
                     </div>
 
+                    <div class="form-check mb-4">
+                        <input class="form-check-input" type="checkbox" id="must_change_password" name="must_change_password"
+                               {% if (user and user.must_change_password) or (not user) %}checked{% endif %}>
+                        <label class="form-check-label" for="must_change_password">
+                            Require password change on first login
+                        </label>
+                    </div>
+
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary">
                             <i class="bi bi-check-lg me-1"></i>{{ 'Update' if user else 'Create' }} User

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,5 @@ import sys
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key")

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -1,0 +1,94 @@
+import os
+import tempfile
+import unittest
+
+from app import create_app, db
+from app.models import AppUser
+
+
+class TestPasswordChangeFlow(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+            SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        user = AppUser(username="forced", role="admin", must_change_password=True)
+        user.set_password("old-password")
+        db.session.add(user)
+        db.session.commit()
+
+    def tearDown(self) -> None:
+        db.session.remove()
+        db.drop_all()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+
+    def _login(self, password: str) -> None:
+        return self.client.post(
+            "/login",
+            data={"username": "forced", "password": password},
+            follow_redirects=False,
+        )
+
+    def test_new_user_login_forces_password_change(self) -> None:
+        response = self._login("old-password")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/account/password", response.headers.get("Location", ""))
+
+    def test_password_change_clears_flag_and_allows_navigation(self) -> None:
+        self._login("old-password")
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "old-password",
+                "new_password": "new-password",
+                "confirm_password": "new-password",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/dashboard", response.headers.get("Location", ""))
+
+        user = AppUser.query.filter_by(username="forced").first()
+        self.assertIsNotNone(user)
+        self.assertFalse(user.must_change_password)
+
+        dashboard = self.client.get("/dashboard")
+        self.assertEqual(dashboard.status_code, 200)
+
+    def test_incorrect_current_password_is_rejected(self) -> None:
+        self._login("old-password")
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "wrong-password",
+                "new_password": "new-password",
+                "confirm_password": "new-password",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Current password is incorrect.", response.data)
+
+        user = AppUser.query.filter_by(username="forced").first()
+        self.assertIsNotNone(user)
+        self.assertTrue(user.must_change_password)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve account security by forcing users to set a new password on first login via a `must_change_password` flag. 
- Ensure existing databases are migrated safely and existing users are backfilled to a safe default. 
- Give admins control to require or clear the flag when creating or editing users. 
- Provide a simple user flow and validation for changing passwords and clearing the requirement.

### Description
- Added `must_change_password` boolean to `AppUser` in `app/models.py` and created migration `app/migrations/002_add_users_must_change_password.py` to add the column and backfill existing rows to false. 
- Updated user management to set the flag from the UI (`app/routes.py` in `users_add` and `users_edit`) and added a checkbox to `app/templates/users/form.html`. 
- Implemented password-change flow with a protected route `GET/POST /account/password` in `app/routes.py` and a new template `app/templates/auth/change_password.html` that validates current password, new password, confirmation, and clears `must_change_password` on success. 
- Enforced the flow by updating login logic and adding a `@bp.before_app_request` guard in `app/auth.py` to redirect users with `must_change_password` to the change page, and added nav links in `app/templates/base.html`.

### Testing
- Ran the test suite with `pytest` and all tests passed: `17 passed`. 
- Added `tests/test_password_change.py` to cover (a) login redirect when `must_change_password=True`, (b) successful password change clears the flag and allows normal navigation, and (c) incorrect current password is rejected. 
- Migrations are applied by the existing runner (`app.migrations.runner`) during app startup and were exercised by the test/app startup. 
- No manual production deploys were performed; migrations and behavior should be reviewed in staging before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1589cb8483248ffb412e1d165655)