### PR TITLE
Fix must-change-password handling on user creation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -249,7 +249,7 @@ def users_add():
         username = request.form.get('username', '').strip()
         role = request.form.get('role', '').strip()
         password = request.form.get('password', '')
-        must_change_password = request.form.get('must_change_password', 'on') == 'on'
+        must_change_password = request.form.get('must_change_password') == 'on'
 
         if not username:
             flash('Username is required.', 'error')

--- a/tests/test_user_creation.py
+++ b/tests/test_user_creation.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+import unittest
+
+from app import create_app, db
+from app.models import AppUser
+
+
+class TestUserCreationMustChangePassword(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+            SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        admin = AppUser(username="admin", role="admin", must_change_password=False)
+        admin.set_password("admin-pass")
+        db.session.add(admin)
+        db.session.commit()
+
+    def tearDown(self) -> None:
+        db.session.remove()
+        db.drop_all()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+
+    def _login(self) -> None:
+        return self.client.post(
+            "/login",
+            data={"username": "admin", "password": "admin-pass"},
+            follow_redirects=False,
+        )
+
+    def test_unchecked_must_change_password_creates_user_without_flag(self) -> None:
+        self._login()
+        response = self.client.post(
+            "/users/add",
+            data={
+                "username": "new-user",
+                "role": "social_manager",
+                "password": "new-pass",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        user = AppUser.query.filter_by(username="new-user").first()
+        self.assertIsNotNone(user)
+        self.assertFalse(user.must_change_password)
+
+    def test_checked_must_change_password_creates_user_with_flag(self) -> None:
+        self._login()
+        response = self.client.post(
+            "/users/add",
+            data={
+                "username": "new-user-2",
+                "role": "social_manager",
+                "password": "new-pass",
+                "must_change_password": "on",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        user = AppUser.query.filter_by(username="new-user-2").first()
+        self.assertIsNotNone(user)
+        self.assertTrue(user.must_change_password)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The add-user handler defaulted the `must_change_password` checkbox to true when the field was omitted, causing newly created users to always be forced to change their password.
- Unchecked HTML checkboxes are not submitted, so the previous default hid the intended behavior and prevented admins from disabling the requirement via the UI.
- The edit path already treated the checkbox as present/absent, so creation should match that behavior for consistency.

### Description
- Update `app/routes.py` to compute the flag with `must_change_password = request.form.get('must_change_password') == 'on'` so the flag is only true when the checkbox is submitted.
- Add `tests/test_user_creation.py` with two tests verifying that an unchecked submission results in `must_change_password == False` and a checked submission results in `True`.
- No other user-management behavior was changed; creation now aligns with the existing edit handling.

### Testing
- Ran the test suite with `pytest -q`.
- All tests passed: `19 passed in 5.20s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f188e1ecc8324a09c8b4e76d2bfb0)