### PR TITLE
Harden deployment install defaults and systemd PATH

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DBDOCTOR_SRC="${REPO_ROOT}/bin/dbdoctor"
 DBDOCTOR_DEST="${DBDOCTOR_DEST:-/usr/local/bin/dbdoctor}"
+ENV_FILE="/opt/sms-admin/.env"
+DEFAULT_REDIS_URL="redis://localhost:6379/0"
+DEFAULT_RQ_QUEUE_NAME="sms"
 
 if [[ ! -f "${DBDOCTOR_SRC}" ]]; then
   echo "ERROR: ${DBDOCTOR_SRC} not found. Did you clone the repo to ${REPO_ROOT}?" >&2
@@ -13,3 +16,39 @@ fi
 sudo install -m 0755 "${DBDOCTOR_SRC}" "${DBDOCTOR_DEST}"
 
 echo "Installed dbdoctor to ${DBDOCTOR_DEST}"
+
+sudo touch "${ENV_FILE}"
+sudo chown root:smsadmin "${ENV_FILE}"
+sudo chmod 640 "${ENV_FILE}"
+
+ensure_env_key() {
+  local key="$1"
+  local value="$2"
+  if ! sudo grep -qE "^${key}=" "${ENV_FILE}"; then
+    echo "${key}=${value}" | sudo tee -a "${ENV_FILE}" >/dev/null
+  fi
+}
+
+ensure_env_key "REDIS_URL" "${DEFAULT_REDIS_URL}"
+ensure_env_key "RQ_QUEUE_NAME" "${DEFAULT_RQ_QUEUE_NAME}"
+
+echo "Running dbdoctor --apply"
+sudo "${DBDOCTOR_DEST}" --apply
+
+sudo install -m 0644 "${REPO_ROOT}/deploy/sms.service" /etc/systemd/system/sms.service
+sudo install -m 0644 "${REPO_ROOT}/deploy/sms-worker.service" /etc/systemd/system/sms-worker.service
+sudo install -m 0644 "${REPO_ROOT}/deploy/sms-scheduler.service" /etc/systemd/system/sms-scheduler.service
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now sms sms-worker sms-scheduler
+
+echo "Deploy report:"
+set +e
+if command -v redis-cli >/dev/null 2>&1; then
+  redis-cli ping
+else
+  echo "redis-cli not found"
+fi
+systemctl status --no-pager sms sms-worker sms-scheduler
+journalctl -u sms-worker -n 30 --no-pager
+set -e

--- a/deploy/sms-scheduler.service
+++ b/deploy/sms-scheduler.service
@@ -6,7 +6,7 @@ After=network.target
 User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
-Environment="PATH=/opt/sms-admin/venv/bin"
+Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 EnvironmentFile=/opt/sms-admin/.env
 ExecStartPre=/usr/local/bin/dbdoctor --apply
 ExecStart=/opt/sms-admin/venv/bin/python -m app.scheduler_runner

--- a/deploy/sms-worker.service
+++ b/deploy/sms-worker.service
@@ -6,7 +6,7 @@ After=network.target redis.service
 User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
-Environment="PATH=/opt/sms-admin/venv/bin"
+Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="SCHEDULER_ENABLED=0"
 Environment="RQ_QUEUE_NAME=sms"
 EnvironmentFile=/opt/sms-admin/.env

--- a/deploy/sms.service
+++ b/deploy/sms.service
@@ -6,7 +6,7 @@ After=network.target
 User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
-Environment="PATH=/opt/sms-admin/venv/bin"
+Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="SCHEDULER_ENABLED=0"
 EnvironmentFile=/opt/sms-admin/.env
 ExecStartPre=/usr/local/bin/dbdoctor --apply


### PR DESCRIPTION
### Motivation
- The RQ worker failed to start on a clean VM because systemd `PATH` was restricted so `ExecStartPre` (`/usr/local/bin/dbdoctor` which uses `#!/usr/bin/env bash`) could not find `bash`.
- A missing `/opt/sms-admin/.env` caused `REDIS_URL` and `RQ_QUEUE_NAME` to be empty during startup, producing confusing `--url ""` behavior.
- The deployment should work on a fresh machine without manual edits to systemd unit files or environment files.

### Description
- The install script now ensures the env file exists at `/opt/sms-admin/.env`, sets `root:smsadmin` ownership and mode `640`, and is idempotent when creating it.
- The installer adds idempotent `ensure_env_key` logic to populate `REDIS_URL=redis://localhost:6379/0` and `RQ_QUEUE_NAME=sms` if they are missing.
- The installer installs `dbdoctor` to `/usr/local/bin` and runs `dbdoctor --apply`, installs the systemd unit files to `/etc/systemd/system`, runs `systemctl daemon-reload`, and `systemctl enable --now sms sms-worker sms-scheduler` during deploy.
- The systemd unit files were updated to expand `Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"` so system binaries (like `bash`) are available, and the installer prints a deploy report (including running `redis-cli ping`, `systemctl status` for the services, and `journalctl -u sms-worker -n 30`); to smoke-test on a fresh box run `sudo bash deploy/install.sh`.

### Testing
- No automated tests were executed for these install-script-only changes.
- Changes were committed and a PR prepared for review; manual smoke testing is expected via `sudo bash deploy/install.sh` on a fresh VM.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1b5eab608324ab2bbe5c741fe58a)