### PR TITLE
Add worker run script

### DIFF
--- a/deploy/run_worker.sh
+++ b/deploy/run_worker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH=/usr/bin:/bin:/opt/sms-admin/venv/bin
+
+if [ -f /opt/sms-admin/.env ]; then
+  set -a
+  . /opt/sms-admin/.env
+  set +a
+fi
+
+: "${REDIS_URL:=redis://localhost:6379/0}"
+: "${RQ_QUEUE_NAME:=sms}"
+
+exec /opt/sms-admin/venv/bin/rq worker --url "$REDIS_URL" "$RQ_QUEUE_NAME"


### PR DESCRIPTION
### Motivation

- Provide a small, deterministic entrypoint to run the RQ worker with predictable environment loading and sane defaults.
- Ensure the worker runs using the project virtualenv on PATH and can pick up an optional `/opt/sms-admin/.env` file safely.

### Description

- Add executable `deploy/run_worker.sh` with `#!/usr/bin/env bash` and `set -euo pipefail` to fail fast and avoid unbound variables.
- Set `PATH` to `/usr/bin:/bin:/opt/sms-admin/venv/bin` and source `/opt/sms-admin/.env` when present using `set -a; . /opt/sms-admin/.env; set +a` to export variables.
- Provide defaults `REDIS_URL=redis://localhost:6379/0` and `RQ_QUEUE_NAME=sms` and `exec` the worker with `/opt/sms-admin/venv/bin/rq worker --url "$REDIS_URL" "$RQ_QUEUE_NAME"`.
- Commit the new file with mode `0755` so it is executable.

### Testing

- No automated tests were run for this change.
- Commands executed during the rollout include `ls`, `find deploy -name AGENTS.md -print`, creation of the file via `cat <<'EOF' > deploy/run_worker.sh`, `chmod 0755 deploy/run_worker.sh`, `git status --short`, `git add deploy/run_worker.sh`, `git commit -m "Add worker run script"`, and `nl -ba deploy/run_worker.sh`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f281fb29c832495f7274d9ae9be3b)