### PR TITLE
Use venv python for dbdoctor and run worker via wrapper in sms-worker.service

### DIFF
--- a/deploy/sms-worker.service
+++ b/deploy/sms-worker.service
@@ -6,12 +6,11 @@ After=network.target redis.service
 User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
-Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="SCHEDULER_ENABLED=0"
 Environment="RQ_QUEUE_NAME=sms"
 EnvironmentFile=/opt/sms-admin/.env
-ExecStartPre=/usr/local/bin/dbdoctor --apply
-ExecStart=/opt/sms-admin/venv/bin/rq worker --url ${REDIS_URL} ${RQ_QUEUE_NAME}
+ExecStartPre=/opt/sms-admin/venv/bin/python -m app.dbdoctor --apply
+ExecStart=/bin/bash /opt/sms-admin/deploy/run_worker.sh
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
### Motivation
- Ensure `dbdoctor` runs with the virtualenv Python to avoid import/path issues when applying DB changes before the worker starts.
- Start the RQ worker via an explicit wrapper script to centralize startup behavior and environment management in `run_worker.sh`.
- Remove reliance on a PATH override in the unit file and keep `WorkingDirectory` and `EnvironmentFile` usage to ensure consistent environment loading.

### Description
- Kept `WorkingDirectory=/opt/sms-admin` and `EnvironmentFile=/opt/sms-admin/.env` unchanged.
- Removed the `Environment="PATH=..."` override from the unit file.
- Replaced `ExecStartPre` with `ExecStartPre=/opt/sms-admin/venv/bin/python -m app.dbdoctor --apply` to use the venv Python.
- Replaced `ExecStart` with `ExecStart=/bin/bash /opt/sms-admin/deploy/run_worker.sh` to launch the worker via the wrapper script.

### Testing
- No automated tests were run for this change (service unit file update only).
- Commands executed during the change: `ls`, `cat deploy/sms-worker.service`, `ls deploy`, `git status -sb`, `git add deploy/sms-worker.service`, `git commit -m "Update sms worker service commands"`, and `nl -ba deploy/sms-worker.service`.
- Changes were committed to the branch and the updated unit file contents were inspected successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2824e2948324834c0725615b6fca)