### PR TITLE
Rollback SQLAlchemy session after MessageLog OperationalError

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,6 +58,7 @@ def dashboard():
             recent_logs = MessageLog.query.order_by(MessageLog.created_at.desc()).limit(5).all()
         except OperationalError as exc:
             from flask import current_app
+            db.session.rollback()
             current_app.logger.warning(
                 'MessageLog query failed due to schema mismatch: %s',
                 exc,


### PR DESCRIPTION
### Motivation
- `MessageLog` queries against an older SQLite schema can raise `sqlalchemy.exc.OperationalError`, leaving the SQLAlchemy session in a failed transaction state.
- A failed session leads to `PendingRollbackError` on subsequent queries (e.g. `ScheduledMessage.query.filter_by(...).count()`), causing `/dashboard` to 500 even when the original `OperationalError` was handled.
- The change ensures the session is reset so the app can continue serving endpoints while schema drift is corrected.

### Description
- Update `app/routes.py` in the dashboard context to call `db.session.rollback()` inside the `except OperationalError` block before logging the error. 
- This prevents a pending rollback state so later queries in the same request do not raise `PendingRollbackError`.
- Change is minimal and scoped to the `build_dashboard_context()` error handler for `MessageLog` queries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2ac5f3888324842442c399a6ee91)