### PR TITLE
Add run_worker.sh wrapper and install it for sms-worker.service

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -38,6 +38,8 @@ sudo "${DBDOCTOR_DEST}" --apply
 sudo install -m 0644 "${REPO_ROOT}/deploy/sms.service" /etc/systemd/system/sms.service
 sudo install -m 0644 "${REPO_ROOT}/deploy/sms-worker.service" /etc/systemd/system/sms-worker.service
 sudo install -m 0644 "${REPO_ROOT}/deploy/sms-scheduler.service" /etc/systemd/system/sms-scheduler.service
+sudo install -d /opt/sms-admin/deploy
+sudo install -m 0755 "${REPO_ROOT}/deploy/run_worker.sh" /opt/sms-admin/deploy/run_worker.sh
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now sms sms-worker sms-scheduler

--- a/deploy/run_worker.sh
+++ b/deploy/run_worker.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VENV_PY="/opt/sms-admin/venv/bin/python"
+
+: "${REDIS_URL:=redis://localhost:6379/0}"
+: "${RQ_QUEUE_NAME:=sms}"
+
+exec "${VENV_PY}" -m rq worker --url "${REDIS_URL}" "${RQ_QUEUE_NAME}"


### PR DESCRIPTION
### Motivation
- Ensure the `ExecStart` referenced by `sms-worker.service` (`/opt/sms-admin/deploy/run_worker.sh`) actually exists so systemd will not fail with `status=203/EXEC` on fresh installs.
- Run the RQ worker using the project's virtualenv Python and centralize startup/environment handling in a single wrapper script.
- Make installer idempotently place the wrapper into the runtime location so deployed systems can start the worker reliably.

### Description
- Add `deploy/run_worker.sh` which execs the venv Python at `/opt/sms-admin/venv/bin/python` to run `-m rq worker` and reads `REDIS_URL` and `RQ_QUEUE_NAME` with sensible defaults.
- Update `deploy/install.sh` to create `/opt/sms-admin/deploy` and install `deploy/run_worker.sh` as `/opt/sms-admin/deploy/run_worker.sh` with `0755` permissions.
- No changes were made to the existing `sms-worker.service` unit other than ensuring its referenced wrapper is provided and installed.

### Testing
- No automated tests were run for this change (service/unit file and installer updates only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2ae72d348324b0c3c848c4397326)