### PR TITLE
Record Twilio init failures in bulk SMS job

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -49,7 +49,19 @@ def send_bulk_job(log_id: int, recipient_data: list, final_message: str, delay: 
         total_recipients = len(recipient_data)
         start_index = len(details)
 
-        twilio = get_twilio_service()
+        try:
+            twilio = get_twilio_service()
+        except Exception as exc:
+            details.append({
+                'phone': '',
+                'name': '',
+                'success': False,
+                'error': str(exc),
+            })
+            failure_count += 1
+            log.status = 'failed'
+            _persist_progress(log, total_recipients, success_count, failure_count, details)
+            return
 
         for recipient in recipient_data[start_index:]:
             phone = recipient.get('phone')


### PR DESCRIPTION
### Motivation
- Ensure errors during Twilio client initialization are recorded instead of leaving a `MessageLog` stuck in `processing` when `get_twilio_service()` raises.
- Persist a checkpoint and error details so the UI and retry logic accurately reflect a failed job.
- Preserve existing per-recipient checkpointing semantics while handling service init failures.

### Description
- Wrapped the `get_twilio_service()` call in `send_bulk_job` with a `try/except` to catch initialization errors. 
- On exception the job now appends a failure entry to `details`, increments `failure_count`, sets `log.status = 'failed'`, and calls `_persist_progress` before returning. 
- Change made in `app/tasks.py` and uses existing helpers `_load_details` and `_persist_progress` to persist state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2b9f7e4083248b97a88d314416c9)