### PR TITLE
Make /opt/sms-admin/.env group-writable and document permission model

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,20 @@ sudo /opt/sms-admin/deploy/install.sh
 
 ### 6. Configure Environment Variables
 
+The installer creates `/opt/sms-admin/.env` as `root:smsadmin` with `660` permissions so
+members of the `smsadmin` group can update it. If your deploy user is not in that group,
+either add them or edit the file via `sudo`.
+
 ```bash
-# Create .env file (readable only by smsadmin)
-sudo -u smsadmin bash -c 'cat > /opt/sms-admin/.env << EOF
+# Create .env file (root:smsadmin, group-writable)
+sudo install -m 660 -o root -g smsadmin /dev/null /opt/sms-admin/.env
+sudo tee /opt/sms-admin/.env >/dev/null << 'EOF'
 TWILIO_ACCOUNT_SID=your_account_sid_here
 TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FROM_NUMBER=+1234567890
 SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
 FLASK_ENV=production
-EOF'
-
-sudo chmod 600 /opt/sms-admin/.env
+EOF
 ```
 
 ### 7. Initialize Database

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DBDOCTOR_SRC="${REPO_ROOT}/bin/dbdoctor"
 DBDOCTOR_DEST="${DBDOCTOR_DEST:-/usr/local/bin/dbdoctor}"
 ENV_FILE="/opt/sms-admin/.env"
+DEPLOY_USER="${SUDO_USER:-$(id -un)}"
 DEFAULT_REDIS_URL="redis://localhost:6379/0"
 DEFAULT_RQ_QUEUE_NAME="sms"
 
@@ -19,7 +20,12 @@ echo "Installed dbdoctor to ${DBDOCTOR_DEST}"
 
 sudo touch "${ENV_FILE}"
 sudo chown root:smsadmin "${ENV_FILE}"
-sudo chmod 640 "${ENV_FILE}"
+sudo chmod 660 "${ENV_FILE}"
+
+if ! id -nG "${DEPLOY_USER}" | tr ' ' '\n' | grep -qx smsadmin; then
+  sudo usermod -aG smsadmin "${DEPLOY_USER}"
+  echo "Added ${DEPLOY_USER} to smsadmin group for .env access."
+fi
 
 ensure_env_key() {
   local key="$1"


### PR DESCRIPTION
### Motivation

- Fix a deploy-time permission issue where the deploy user could not write to `/opt/sms-admin/.env` (e.g., writing `APP_VERSION`).
- Ensure the intended deploy user can update environment variables without needing to change file ownership each time.
- Provide clear documentation of the chosen permission model so deployers understand whether to edit via `sudo` or be added to the `smsadmin` group.

### Description

- Updated `deploy/install.sh` to set `DEPLOY_USER` from `SUDO_USER` or `id -un`, change `.env` permissions to `660` with `sudo chmod 660 "${ENV_FILE}"`, and add the deploy user to the `smsadmin` group if they are not already a member.
- Left existing creation and owner of `/opt/sms-admin/.env` as `root:smsadmin` but made it group-writable so group members can edit it.
- Updated `README.md` `Configure Environment Variables` instructions to create `/opt/sms-admin/.env` as `root:smsadmin` with `660` permissions using `sudo install -m 660 -o root -g smsadmin /dev/null /opt/sms-admin/.env` and to populate it with `sudo tee`.
- Added a short explanatory note in `README.md` describing that members of `smsadmin` can update the file or edits can be performed via `sudo`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f301798f08324ba665b332770020f)