### PR TITLE
Make scheduled message expiry configurable and log late sends

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,7 @@ class Config:
 
     # Scheduler (disable by default in production; run as a separate service)
     SCHEDULER_ENABLED = os.environ.get('SCHEDULER_ENABLED', '1' if DEBUG else '0') == '1'
+    SCHEDULED_MESSAGE_MAX_LAG = int(os.environ.get('SCHEDULED_MESSAGE_MAX_LAG', '1440'))
 
     APP_TIMEZONE = os.environ.get('APP_TIMEZONE', 'UTC')
 


### PR DESCRIPTION
### Motivation
- Replace the hard-coded 5-minute expiry to allow configurable lag or no auto-expiry for scheduled messages.
- Allow the system to still send messages that are late while annotating these as "late send" in logs instead of silently dropping them.
- Ensure `ScheduledMessage` status updates continue to reflect real send success or failure and avoid permanently losing messages just for being late.

### Description
- Add `SCHEDULED_MESSAGE_MAX_LAG` to `app/config.py` with a default of `1440` minutes (1 day) and loadable from environment.
- Update `app/services/scheduler_service.py` to read `SCHEDULED_MESSAGE_MAX_LAG` via `current_app.config` and compute `expiry_threshold` only when the configured value is present and > 0.
- Treat messages older than the configured max lag as `expired` with an updated `error_message`, and otherwise log a late send with a `"Late send"` print message while still attempting delivery.
- Keep existing behavior for marking stuck `processing` messages as `failed` and preserve success/failure updates and message logging when sends are attempted.

### Testing
- No automated tests were run for this change. 
- Recommended test command to run locally is `pytest` to validate full test coverage after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3d156f4c8324b4fcb1ae5d3ee399)