### PR TITLE
Gate scheduler startup behind runner flag

### DIFF
--- a/app/scheduler_runner.py
+++ b/app/scheduler_runner.py
@@ -18,7 +18,7 @@ signal.signal(signal.SIGINT, _handle_shutdown)
 
 
 def main():
-    create_app()
+    create_app(start_scheduler=True)
 
     while not _shutdown_requested:
         time.sleep(1)

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -37,7 +37,7 @@ def _persist_progress(
 
 
 def send_bulk_job(log_id: int, recipient_data: list, final_message: str, delay: float = 0.1) -> None:
-    app = create_app()
+    app = create_app(start_scheduler=False)
     with app.app_context():
         log = MessageLog.query.get(log_id)
         if not log:

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,6 @@
 from app import create_app
 
-app = create_app()
+app = create_app(start_scheduler=False)
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
### Motivation
- Prevent the background scheduler from starting automatically in non-runner contexts (web app, RQ tasks).
- Make the scheduler runner an explicit opt-in via `SCHEDULER_RUNNER=1` or `start_scheduler=True`.
- Ensure other entry points explicitly disable scheduler startup to avoid duplicate schedulers or unexpected background work.
- Surface a warning when `SCHEDULER_ENABLED` is true but the scheduler is not started in the current process.

### Description
- Updated `create_app(...)` to consult `SCHEDULER_RUNNER` when `start_scheduler` is not provided and require both the runner flag and `SCHEDULER_ENABLED` to call `init_scheduler`, with improved info/warning logs.
- Changed `app/scheduler_runner.py` to call `create_app(start_scheduler=True)` so the runner explicitly requests scheduler startup.
- Updated `wsgi.py` and `app/tasks.py` to call `create_app(start_scheduler=False)` to ensure web and RQ task contexts do not start the scheduler.
- Added log messages for the cases where the runner is requested but `SCHEDULER_ENABLED` is false, and when `SCHEDULER_ENABLED` is true but the scheduler is not started.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3dc5581483249af1b67e15d4da99)