### PR TITLE
Fail fast on non-SQLite engines when SQLite migrations exist

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -48,8 +48,14 @@ def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] =
     if run_startup_tasks:
         # Create database tables and run migrations
         with app.app_context():
+            from app.migrations.runner import (
+                check_migrations_compatibility,
+                inspect_migrations,
+                run_pending_migrations,
+            )
+
+            check_migrations_compatibility(db.engine, app.logger)
             db.create_all()
-            from app.migrations.runner import inspect_migrations, run_pending_migrations
 
             run_pending_migrations(db.engine, app.logger)
             migration_report = inspect_migrations(db.engine)


### PR DESCRIPTION
### Motivation
- Prevent production startup from proceeding when the app contains SQLite-only migration files but is configured to use a non-SQLite database.
- Surface a clear, actionable error early during app initialization so operators know to run equivalent migrations (e.g., via Alembic) or switch to SQLite.

### Description
- Added `_non_sqlite_migration_message` to generate a clear guidance string listing found SQLite migrations and the detected driver.
- Added `check_migrations_compatibility(engine, logger)` which raises a `RuntimeError` when migrations exist but the engine is non-SQLite.
- Updated `run_pending_migrations` to raise the same `RuntimeError` instead of silently skipping when a non-SQLite engine is detected.
- Invoked `check_migrations_compatibility` from `create_app` before calling `db.create_all()` so startup fails fast on incompatible setups.

### Testing
- No automated tests were run against these changes.
- Commands inspected during the rollout include `sed -n '1,200p' app/migrations/runner.py`, `sed -n '1,200p' app/__init__.py`, `nl -ba app/migrations/runner.py`, and `nl -ba app/__init__.py` to review the modified files.
- The changes were applied and the codebase updated; runtime verification in a target environment is recommended to confirm behavior with non-SQLite engines.
- If desired, run `pytest` and start the app with a non-SQLite `SQLALCHEMY_DATABASE_URI` to validate the new failure mode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3e90ff708324bfc407255b1989b3)