### PR TITLE
Fix README secret key generation in env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ either add them or edit the file via `sudo`.
 ```bash
 # Create .env file (root:smsadmin, group-writable)
 sudo install -m 660 -o root -g smsadmin /dev/null /opt/sms-admin/.env
-sudo tee /opt/sms-admin/.env >/dev/null << 'EOF'
+sudo tee /opt/sms-admin/.env >/dev/null << EOF
 TWILIO_ACCOUNT_SID=your_account_sid_here
 TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FROM_NUMBER=+1234567890


### PR DESCRIPTION
### Motivation

- The `.env` heredoc in the README was quoted (`<< 'EOF'`) which prevented shell command substitution and caused the literal `SECRET_KEY=$(...)` line to be written into the file.
- That behavior can produce a predictable, non-random `SECRET_KEY` for users who follow the README, weakening session/CSRF security.
- The intent is for the `SECRET_KEY` to be generated at install time by the example, so the README must allow shell expansion.
- This fix is documentation-only and is intended to restore the secure, intended behavior of the install snippet.

### Description

- Updated `README.md` to change the `.env` creation snippet from `sudo tee /opt/sms-admin/.env >/dev/null << 'EOF'` to `sudo tee /opt/sms-admin/.env >/dev/null << EOF` so shell expansion is enabled.
- As a result, the example `SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")` will be evaluated when the snippet is executed.
- No runtime code, install scripts, or permission guidance for `/opt/sms-admin/.env` were modified.
- The change is scoped to documentation to avoid unintended side effects in deployments.

### Testing

- No automated tests were run because this is a documentation-only change.
- No automated test failures were observed (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4099cfa88324b65571eaec8bd563)