### PR TITLE
Add SuppressedContact model and SQLite migration

### DIFF
--- a/app/migrations/003_add_suppressed_contacts.py
+++ b/app/migrations/003_add_suppressed_contacts.py
@@ -1,0 +1,28 @@
+from sqlalchemy import text
+
+
+def apply(connection, logger) -> None:
+    result = connection.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='suppressed_contacts'"))
+    if result.first() is not None:
+        logger.info("Skipping migration 003_add_suppressed_contacts: table suppressed_contacts already exists.")
+        return
+
+    connection.execute(
+        text(
+            """
+            CREATE TABLE suppressed_contacts (
+                id INTEGER PRIMARY KEY,
+                phone VARCHAR(20) NOT NULL UNIQUE,
+                reason TEXT,
+                category VARCHAR(20) NOT NULL,
+                source VARCHAR(50),
+                source_type VARCHAR(50),
+                source_message_log_id INTEGER,
+                created_at TEXT,
+                updated_at TEXT,
+                FOREIGN KEY(source_message_log_id) REFERENCES message_logs (id)
+            )
+            """
+        )
+    )
+    logger.info("Migration 003_add_suppressed_contacts: created suppressed_contacts table.")


### PR DESCRIPTION
### Motivation
- Add a first-class suppression table to track phones that should not receive messages (opt-outs, hard/soft failures, etc.).
- Persist metadata and a link back to the originating `MessageLog` for auditing and automated suppression logic.
- Ensure phone values are normalized to E.164 on write to keep uniqueness and lookups consistent.

### Description
- Introduced `SuppressedContact` model in `app/models.py` with fields `id`, `phone` (unique), `reason`, `category`, `source`, `source_type`, `source_message_log_id`, `created_at`, and `updated_at`.
- Phone normalization is applied via `@validates('phone')` using `normalize_phone` from `app.utils` so numbers are stored in E.164-like form.
- Added a relationship `message_log` to `MessageLog` and new imports (`validates`, `normalize_phone`) in `app/models.py`.
- Added SQLite migration `app/migrations/003_add_suppressed_contacts.py` which creates the `suppressed_contacts` table and is compatible with the existing migration runner by skipping creation if the table already exists.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f455b4cb48324a0be58533008d374)