### PR TITLE
Add suppression service for delivery failure classification

### DIFF
--- a/app/services/suppression_service.py
+++ b/app/services/suppression_service.py
@@ -1,0 +1,168 @@
+from typing import Literal
+
+from flask import current_app
+
+from app import db
+from app.models import SuppressedContact, UnsubscribedContact, utc_now
+from app.utils import normalize_phone
+
+
+OptOutCategory = Literal['opt_out', 'hard_fail', 'soft_fail']
+
+
+def classify_failure(error_text: str) -> OptOutCategory:
+    if not error_text:
+        return 'soft_fail'
+
+    message = error_text.lower()
+
+    opt_out_patterns = [
+        'unsubscribed',
+        'opted out',
+        'opt-out',
+        'opt out',
+        'stop',
+        'reply stop',
+        'unsubscribe',
+        'cancel',
+        'quit',
+        'end',
+        'blocked',
+        'recipient has opted out',
+        'opt-out',
+        '21610',
+        '30004',
+    ]
+    hard_fail_patterns = [
+        'invalid',
+        'not a valid',
+        'does not exist',
+        'unknown subscriber',
+        'unreachable',
+        'landline',
+        'not a mobile',
+        'no route',
+        'unassigned',
+        'number is not valid',
+        'phone number is not',
+        'carrier violation',
+        '30003',
+        '30005',
+        '30007',
+    ]
+    soft_fail_patterns = [
+        'temporarily',
+        'timeout',
+        'timed out',
+        'rate limit',
+        'throttle',
+        'too many requests',
+        'network',
+        'connection',
+        'service unavailable',
+        'server error',
+        'unavailable',
+        'gateway',
+        '429',
+        '500',
+        '502',
+        '503',
+        '504',
+    ]
+
+    if any(pattern in message for pattern in opt_out_patterns):
+        return 'opt_out'
+    if any(pattern in message for pattern in hard_fail_patterns):
+        return 'hard_fail'
+    if any(pattern in message for pattern in soft_fail_patterns):
+        return 'soft_fail'
+
+    return 'soft_fail'
+
+
+def process_failure_details(details: list, source_message_log_id: int) -> dict:
+    counts = {
+        'total': len(details),
+        'failed': 0,
+        'opt_out': 0,
+        'hard_fail': 0,
+        'soft_fail': 0,
+        'unsubscribed_upserts': 0,
+        'suppressed_upserts': 0,
+        'skipped_no_phone': 0,
+    }
+
+    def get_phone(entry: dict) -> str:
+        return entry.get('phone') or entry.get('to') or entry.get('recipient') or ''
+
+    with db.session.begin():
+        for detail in details:
+            success = detail.get('success')
+            status = detail.get('status')
+            error_text = detail.get('error') or detail.get('message') or ''
+
+            if success is True:
+                continue
+            if success is None and not error_text and status not in {'failed', 'undelivered'}:
+                continue
+
+            counts['failed'] += 1
+            normalized_phone = normalize_phone(get_phone(detail))
+            if not normalized_phone:
+                counts['skipped_no_phone'] += 1
+                continue
+
+            category = classify_failure(error_text)
+            counts[category] += 1
+
+            if category == 'opt_out':
+                existing = UnsubscribedContact.query.filter_by(phone=normalized_phone).first()
+                if existing:
+                    existing.source = 'message_failure'
+                    if detail.get('name') and not existing.name:
+                        existing.name = detail.get('name')
+                else:
+                    db.session.add(
+                        UnsubscribedContact(
+                            name=detail.get('name'),
+                            phone=normalized_phone,
+                            source='message_failure',
+                        )
+                    )
+                counts['unsubscribed_upserts'] += 1
+            elif category == 'hard_fail':
+                existing = SuppressedContact.query.filter_by(phone=normalized_phone).first()
+                if existing:
+                    existing.reason = error_text
+                    existing.category = category
+                    existing.source = 'message_failure'
+                    existing.source_type = 'message_log'
+                    existing.source_message_log_id = source_message_log_id
+                    existing.updated_at = utc_now()
+                else:
+                    db.session.add(
+                        SuppressedContact(
+                            phone=normalized_phone,
+                            reason=error_text,
+                            category=category,
+                            source='message_failure',
+                            source_type='message_log',
+                            source_message_log_id=source_message_log_id,
+                        )
+                    )
+                counts['suppressed_upserts'] += 1
+
+    current_app.logger.info(
+        "Processed failure details: total=%s failed=%s opt_out=%s hard_fail=%s soft_fail=%s "
+        "unsubscribed_upserts=%s suppressed_upserts=%s skipped_no_phone=%s",
+        counts['total'],
+        counts['failed'],
+        counts['opt_out'],
+        counts['hard_fail'],
+        counts['soft_fail'],
+        counts['unsubscribed_upserts'],
+        counts['suppressed_upserts'],
+        counts['skipped_no_phone'],
+    )
+
+    return counts


### PR DESCRIPTION
### Motivation
- Provide a consistent way to classify SMS delivery failures and map them to opt-outs, hard failures, or soft failures.
- Normalize recipient phone numbers and ensure suppression/unsubscribe records are created or updated idempotently.
- Perform all DB upserts in a single transaction to avoid partial writes on processing failure details.
- Emit structured logging of counts to help operators monitor how many recipients were classified and upserted.

### Description
- Add `app/services/suppression_service.py` with `classify_failure(error_text: str)` and `process_failure_details(details: list, source_message_log_id: int)`.
- `classify_failure` uses pattern lists to return one of `'opt_out'`, `'hard_fail'`, or `'soft_fail'` based on the provider error text.
- `process_failure_details` normalizes phones via `normalize_phone`, filters failed recipients, and upserts `UnsubscribedContact` for opt-outs and `SuppressedContact` for hard-fails inside a `db.session.begin()` transaction.
- Upserts are idempotent (unique by phone) and update `reason`/`source`/`updated_at` on repeats, and the function logs processing counts via `current_app.logger.info(...)`.

### Testing
- No automated tests were run against these changes.
- No new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4624242c83249daa3df6491758ff)