### PR TITLE
Add async backfill action and UI feedback for suppression logs

### DIFF
--- a/app/templates/unsubscribed/list.html
+++ b/app/templates/unsubscribed/list.html
@@ -12,9 +12,9 @@
 
 {% block page_actions %}
 {% if can_manage_unsubscribed %}
-<form method="POST" action="{{ url_for('main.unsubscribed_backfill') }}" class="d-inline">
+<form method="POST" action="{{ url_for('main.unsubscribed_backfill') }}" class="d-inline" data-backfill-form>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <button type="submit" class="btn btn-outline-warning" onclick="return confirm('Run suppression backfill from message logs?');">
+    <button type="submit" class="btn btn-outline-warning" data-backfill-button>
         <i class="bi bi-arrow-repeat me-1"></i>Backfill from Logs
     </button>
 </form>
@@ -31,6 +31,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="alert alert-success d-none" role="status" aria-live="polite" id="backfillAlert"></div>
 <div class="card app-card mb-4">
     <div class="card-body">
         <form method="GET" class="filter-bar" data-table-loading-target="unsubscribedTable">
@@ -127,4 +128,74 @@
     </div>
     {% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    const backfillForm = document.querySelector('[data-backfill-form]');
+    const backfillAlert = document.getElementById('backfillAlert');
+
+    if (backfillForm) {
+        const backfillButton = backfillForm.querySelector('[data-backfill-button]');
+
+        backfillForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+
+            if (!confirm('Run suppression backfill from message logs?')) {
+                return;
+            }
+
+            if (backfillButton) {
+                backfillButton.disabled = true;
+                backfillButton.classList.add('disabled');
+                backfillButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Running backfill...';
+            }
+
+            if (backfillAlert) {
+                backfillAlert.classList.add('d-none');
+                backfillAlert.textContent = '';
+            }
+
+            try {
+                const response = await fetch(backfillForm.action, {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    body: new FormData(backfillForm),
+                });
+
+                const payload = await response.json();
+                if (!response.ok) {
+                    throw new Error(payload?.error || 'Backfill failed.');
+                }
+
+                if (backfillAlert) {
+                    backfillAlert.textContent = payload.message;
+                    backfillAlert.classList.remove('d-none');
+                    backfillAlert.classList.remove('alert-danger');
+                    backfillAlert.classList.add('alert-success');
+                } else {
+                    alert(payload.message);
+                }
+            } catch (error) {
+                const message = error instanceof Error ? error.message : 'Backfill failed.';
+                if (backfillAlert) {
+                    backfillAlert.textContent = message;
+                    backfillAlert.classList.remove('d-none');
+                    backfillAlert.classList.remove('alert-success');
+                    backfillAlert.classList.add('alert-danger');
+                } else {
+                    alert(message);
+                }
+            } finally {
+                if (backfillButton) {
+                    backfillButton.disabled = false;
+                    backfillButton.classList.remove('disabled');
+                    backfillButton.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i>Backfill from Logs';
+                }
+            }
+        });
+    }
+</script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- The "Backfill from Logs" button performed a full-page POST with no interactive feedback and provided no error information for async usage.
- Operators need clear success/error feedback and a responsive UI when running the suppression backfill over message logs.

### Description
- Change the backfill endpoint `unsubscribed_backfill` to return JSON when called via XHR and to catch and log exceptions before responding. 
- Wire the suppression list template to submit the backfill form via `fetch()` with a loading state on the button and inline alert UI for success/error messages. 
- Add a dismissible inline alert element (`#backfillAlert`) to surface the result message without a full page reload. 
- Preserve non-AJAX behavior by falling back to flashing messages and redirecting when the request is not XHR.

### Testing
- No automated tests were run against these changes (`pytest` was not executed). 
- Repository inspection and edits were performed using commands such as `rg`, `sed`, `git status`, `git add`, and `git commit`. 
- Manual validation steps are recommended after deployment: trigger the backfill via the UI as an admin to confirm the loading state, success alert, and error handling. 
- Server logs will record exceptions from backfill runs due to added `current_app.logger.exception` on failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f51e045288324bfe2b5743351dd7e)