### PR TITLE
Improve suppression backfill handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1110,7 +1110,9 @@ def unsubscribed_backfill():
 
     message = (
         f"Backfill complete: {summary['logs']} log(s) scanned, "
-        f"{summary['calls']} log(s) processed."
+        f"{summary['calls']} log(s) processed, "
+        f"{summary['unsubscribed']} unsubscribed, "
+        f"{summary['suppressed']} suppressed."
     )
     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         return jsonify({'message': message, 'summary': summary})

--- a/app/templates/unsubscribed/list.html
+++ b/app/templates/unsubscribed/list.html
@@ -162,10 +162,11 @@
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                     },
+                    credentials: 'same-origin',
                     body: new FormData(backfillForm),
                 });
 
-                const payload = await response.json();
+                const payload = await response.json().catch(() => ({}));
                 if (!response.ok) {
                     throw new Error(payload?.error || 'Backfill failed.');
                 }


### PR DESCRIPTION
### Motivation
- Backfill sometimes failed to produce suppression entries because stored message log payloads can be wrapped in objects rather than being a raw list of details.
- The UI backfill action could appear to do nothing when the fetch did not include same-origin credentials or when the server returned a non-JSON response.
- Operators need visibility into how many unsubscribed and suppressed rows were created during a backfill. 

### Description
- Updated `_load_details` in `app/services/suppression_backfill.py` to accept either a list or a dict with a `details`/`results` list and return an empty list for other shapes. 
- Aggregated `unsubscribed_upserts` and `suppressed_upserts` from `process_failure_details` during backfill and added totals to logs and the returned summary. 
- Changed the backfill completion message in `app/routes.py` to include unsubscribed and suppressed counts. 
- Hardened the front-end backfill request in `app/templates/unsubscribed/list.html` by adding `credentials: 'same-origin'` and safely handling non-JSON responses. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5455d2c48324af61adca91bd0a29)