### PR TITLE
Guard suppression backfill against invalid log details

### DIFF
--- a/app/services/suppression_service.py
+++ b/app/services/suppression_service.py
@@ -92,6 +92,7 @@ def process_failure_details(details: list, source_message_log_id: int) -> dict:
         'community_member_deletes': 0,
         'event_registration_deletes': 0,
         'skipped_no_phone': 0,
+        'skipped_invalid': 0,
     }
 
     def get_phone(entry: dict) -> str:
@@ -101,6 +102,9 @@ def process_failure_details(details: list, source_message_log_id: int) -> dict:
 
     with db.session.begin():
         for detail in details:
+            if not isinstance(detail, dict):
+                counts['skipped_invalid'] += 1
+                continue
             success = detail.get('success')
             status = detail.get('status')
             error_text = detail.get('error') or detail.get('message') or ''


### PR DESCRIPTION
### Motivation
- The suppression backfill can crash when message log `details` contain malformed or non-dictionary entries, causing the UI "Backfill from Logs" action to fail.
- Add defensive handling so backfill continues when encountering unexpected detail items and surface a consistent summary instead of raising an exception.

### Description
- Added a new `skipped_invalid` counter to the `counts` returned by `process_failure_details` and increment it when a detail is not a `dict`.
- Early-skip non-dictionary `detail` entries in `app/services/suppression_service.py` to avoid attribute errors during backfill processing.
- No changes to the upsert/delete logic for valid entries; behavior for valid failure details remains unchanged.

### Testing
- Ran `pytest`: 23 tests collected, 21 passed and 2 failed (both in `tests/test_user_creation.py`) due to an `sqlite3.OperationalError: unable to open database file` when creating the test DB, indicating an environment/test setup issue rather than the change itself.
- (No other automated test suites ran successfully against the modified code.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe33d6a108324bd339954decd22c1)