### PR TITLE
Fix mobile nav link visibility

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -247,6 +247,17 @@ h6,
 .app-mobile-nav-panel .app-nav-link {
   justify-content: flex-start;
   width: 100%;
+  color: var(--color-text);
+  background-color: transparent;
+}
+
+.app-mobile-nav-panel .app-nav-link:hover {
+  color: var(--color-text);
+  background-color: var(--color-surface-muted);
+}
+
+.app-mobile-nav-panel .app-nav-link.active {
+  color: #fff;
 }
 
 .app-content {


### PR DESCRIPTION
### Motivation
- The mobile hamburger menu expanded panel showed links with low contrast against the light dropdown background, making them hard to read on small screens.
- The intent is to make inactive links legible while preserving the prominent active state for the current page.
- Keep the change scoped to CSS only so the behavior and markup remain unchanged.

### Description
- Updated `app/static/css/app.css` to set `.app-mobile-nav-panel .app-nav-link` color to `var(--color-text)` and `background-color: transparent` to ensure readable default text.
- Added a hover rule ` .app-mobile-nav-panel .app-nav-link:hover` to use `var(--color-surface-muted)` so inactive links remain visible on interaction.
- Kept the active state styling by ensuring `.app-mobile-nav-panel .app-nav-link.active` continues to use a white text color for contrast against the primary gradient.

### Testing
- Ran `pytest`, which collected 23 tests with 21 passed and 2 failed, where the two failures are `tests/test_user_creation.py` reporting `sqlite3.OperationalError: unable to open database file` and are unrelated to the CSS change.
- Executed an automated Playwright script to render the app at a mobile viewport and capture a screenshot after opening the hamburger menu, which produced a screenshot confirming the improved menu appearance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696058fb9b648324963a1c5d16ff1bdf)