### PR TITLE
Use client timezone for delivery trends

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -59,6 +59,8 @@ def index():
 def dashboard():
     from flask import current_app
     app_timezone = current_app.config.get('APP_TIMEZONE', 'UTC')
+    client_timezone = request.cookies.get('client_timezone', '').strip()
+    dashboard_timezone = client_timezone or app_timezone
     events = Event.query.order_by(Event.date.desc()).all()
     admin_test_phone = current_app.config.get('ADMIN_TEST_PHONE')
 
@@ -66,9 +68,15 @@ def dashboard():
         """Build 7-day delivery trends data for the dashboard chart."""
         tz = None
         try:
-            tz = ZoneInfo(app_timezone)
+            tz = ZoneInfo(dashboard_timezone)
         except Exception:
-            tz = timezone.utc
+            if dashboard_timezone != app_timezone:
+                try:
+                    tz = ZoneInfo(app_timezone)
+                except Exception:
+                    tz = timezone.utc
+            else:
+                tz = timezone.utc
 
         today = datetime.now(tz).date()
         labels = []

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -354,12 +354,24 @@
     const clientTimezone = document.getElementById('client_timezone');
     const timezoneHint = document.getElementById('timezoneHint');
 
+    function getCookieValue(name) {
+        const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : '';
+    }
+
     if (clientTimezone) {
         try {
             const resolvedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
             clientTimezone.value = resolvedTimezone;
             if (timezoneHint) {
                 timezoneHint.textContent = resolvedTimezone || 'Unavailable';
+            }
+            if (resolvedTimezone) {
+                const existingTimezone = getCookieValue('client_timezone');
+                if (existingTimezone !== resolvedTimezone) {
+                    document.cookie = `client_timezone=${encodeURIComponent(resolvedTimezone)}; path=/; max-age=31536000; samesite=lax`;
+                    window.location.reload();
+                }
             }
         } catch (e) {
             clientTimezone.value = '';


### PR DESCRIPTION
### Motivation
- Delivery trends on the dashboard were being computed using the app/UTC timezone which made "today" appear as the next day for users in other timezones.  
- The change aims to make the 7-day chart reflect the user's local date boundaries so trends align with the user's local "today".

### Description
- Read the browser timezone cookie `client_timezone` in `app/routes.py` and derive `dashboard_timezone = client_timezone or app_timezone`.  
- Use `ZoneInfo(dashboard_timezone)` when building chart day boundaries and fall back to the configured `APP_TIMEZONE` then to UTC if necessary.  
- Persist the browser-resolved timezone from `Intl.DateTimeFormat().resolvedOptions().timeZone` into a `client_timezone` cookie from `app/templates/dashboard.html` and reload the page once when it changes so the server-side chart data refreshes with the correct timezone.  
- Minimal UI/JS helper added: `getCookieValue()` and a single-cookie write with `max-age=31536000` and `samesite=lax`.

### Testing
- Ran `pytest` which collected 23 tests and returned 21 passed and 2 failed (both failing in `tests/test_user_creation.py` with `sqlite3.OperationalError: unable to open database file`).  
- Ran `python app/dbdoctor.py` which failed with `ModuleNotFoundError: No module named 'app'`.  
- Attempted `python app/migrate.py` which failed because the file does not exist in this tree.  
- The new code paths were exercised by loading the dashboard in-browser (JS writes the cookie and forces a reload) and unit tests were run as above; the failures appear unrelated to the timezone changes and look like environment/test setup issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69605d62552883249a9bb2b3606727c8)