### PR TITLE
Move Twilio service import to scheduler module scope

### DIFF
--- a/app/services/scheduler_service.py
+++ b/app/services/scheduler_service.py
@@ -5,6 +5,7 @@ import atexit
 from datetime import datetime
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from app.services.twilio_service import get_twilio_service
 
 scheduler = None
 _scheduler_initialized = False
@@ -33,8 +34,6 @@ def send_scheduled_messages(app):
             filter_unsubscribed_recipients,
         )
         from app.services.suppression_service import process_failure_details
-        from app.services.twilio_service import get_twilio_service
-        
         now = datetime.utcnow()
         logger.info("[Scheduler] Starting scheduled messages check at %s UTC", now.isoformat())
         


### PR DESCRIPTION
### Motivation
- Tests need to patch `app.services.scheduler_service.get_twilio_service` for mocking the Twilio client, so the import must exist at module scope. 
- Keeping the import inside a function prevents `get_twilio_service` from being accessible for `patch` in some test setups. 

### Description
- Move `from app.services.twilio_service import get_twilio_service` to the top of `app/services/scheduler_service.py` so `get_twilio_service` is a module-level symbol. 
- Remove the duplicate local import inside `send_scheduled_messages` to avoid shadowing the module-level symbol. 

### Testing
- Ran `pytest`, which executed the test suite and produced `25 passed, 2 failed` with the two failures in `tests/test_user_creation.py` due to `sqlite3.OperationalError: unable to open database file`.
- Ran `python app/dbdoctor.py`, which failed with `ModuleNotFoundError: No module named 'app'`.
- Attempted `python app/migrate.py`, which failed because the file is not present in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a89c733c8324b46937cdc0a6a8c8)