### PR TITLE
Use module-mode dbdoctor commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ This repository welcomes AI agents. Use this guide to work safely, predictably, 
 
 ## 9) Quick ops guide (Codex)
 - **Unit tests:** run `pytest`. If none exist, add focused tests in `tests/` and document how to run them.
-- **DB doctor & migrations:** run `python app/dbdoctor.py` and `python app/migrate.py` (apply migrations before serving).
+- **DB doctor & migrations:** run `python -m app.dbdoctor --print` and `python -m app.dbdoctor --apply` (apply migrations before serving).
 - **Systemd services:** expected units are `sms`, `sms-worker`, and `sms-scheduler.timer`; all load environment from `/opt/sms-admin/.env`.
 - **Scheduler:** uses systemd timer (`sms-scheduler.timer`) that triggers `sms-scheduler.service` (Type=oneshot) every 60 seconds. Do NOT enable `sms-scheduler.service` directly—enable only the timer.
 - **Definition of done (prod):**


### PR DESCRIPTION
### Motivation
- The repository docs and the `bin/dbdoctor` wrapper use module-mode invocations for the DB doctor, so the quick-ops guidance should match that existing pattern.
- `app/dbdoctor.py` uses package imports which makes module mode (`-m app.dbdoctor`) the correct and more robust way to run it.
- Keeping documentation consistent reduces confusion for operators and for systemd `ExecStartPre` usage. 

### Description
- Replaced the DB doctor guidance in `AGENTS.md` to recommend `python -m app.dbdoctor --print` and `python -m app.dbdoctor --apply` instead of file-path script invocation. 
- This is a documentation-only change scoped to `AGENTS.md` and does not modify runtime code or dependencies. 

### Testing
- I ran a quick repository search with `rg` to find references to `dbdoctor` and confirm consistency with `bin/dbdoctor` and `README.md`. 
- I ran the test suite with `pytest`, which executed 27 test files and produced 21 passing and 6 failing tests. 
- The failing tests are unrelated to this documentation change and show two root causes observed during the run: missing `get_twilio_service` attribute in `app.services.scheduler_service` referenced by scheduler tests, and `sqlite3.OperationalError: unable to open database file` encountered by some user-creation tests. 
- No further code changes were made, and the documentation update itself does not affect runtime behavior or tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a8addab8832498e5e25a7a146940)