### PR TITLE
Set DATABASE_URL before loading app config in tests; fix scheduler mocks and dispose DB engine

### DIFF
--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -2,9 +2,6 @@ import os
 import tempfile
 import unittest
 
-from app import create_app, db
-from app.models import AppUser
-
 
 class TestPasswordChangeFlow(unittest.TestCase):
     def setUp(self) -> None:
@@ -12,31 +9,42 @@ class TestPasswordChangeFlow(unittest.TestCase):
         os.environ["FLASK_DEBUG"] = "1"
         self._temp_dir = tempfile.TemporaryDirectory()
         db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+        import importlib
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser
+
+        self.db = db
+        self.AppUser = AppUser
         self.app = create_app(run_startup_tasks=False, start_scheduler=False)
         self.app.config.update(
             TESTING=True,
             WTF_CSRF_ENABLED=False,
-            SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
         )
         self._app_context = self.app.app_context()
         self._app_context.push()
-        db.create_all()
+        self.db.create_all()
         self.client = self.app.test_client()
 
-        user = AppUser(username="forced", role="admin", must_change_password=True)
+        user = self.AppUser(username="forced", role="admin", must_change_password=True)
         user.set_password("old-password")
-        db.session.add(user)
-        db.session.commit()
+        self.db.session.add(user)
+        self.db.session.commit()
 
     def tearDown(self) -> None:
-        db.session.remove()
-        db.drop_all()
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
         self._app_context.pop()
         self._temp_dir.cleanup()
         if self._original_flask_debug is None:
             os.environ.pop("FLASK_DEBUG", None)
         else:
             os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
 
     def _login(self, password: str) -> None:
         return self.client.post(
@@ -64,7 +72,7 @@ class TestPasswordChangeFlow(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("/dashboard", response.headers.get("Location", ""))
 
-        user = AppUser.query.filter_by(username="forced").first()
+        user = self.AppUser.query.filter_by(username="forced").first()
         self.assertIsNotNone(user)
         self.assertFalse(user.must_change_password)
 
@@ -85,7 +93,7 @@ class TestPasswordChangeFlow(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Current password is incorrect.", response.data)
 
-        user = AppUser.query.filter_by(username="forced").first()
+        user = self.AppUser.query.filter_by(username="forced").first()
         self.assertIsNotNone(user)
         self.assertTrue(user.must_change_password)
 

--- a/tests/test_user_creation.py
+++ b/tests/test_user_creation.py
@@ -2,9 +2,6 @@ import os
 import tempfile
 import unittest
 
-from app import create_app, db
-from app.models import AppUser
-
 
 class TestUserCreationMustChangePassword(unittest.TestCase):
     def setUp(self) -> None:
@@ -12,31 +9,42 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
         os.environ["FLASK_DEBUG"] = "1"
         self._temp_dir = tempfile.TemporaryDirectory()
         db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+        import importlib
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser
+
+        self.db = db
+        self.AppUser = AppUser
         self.app = create_app(run_startup_tasks=False, start_scheduler=False)
         self.app.config.update(
             TESTING=True,
             WTF_CSRF_ENABLED=False,
-            SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
         )
         self._app_context = self.app.app_context()
         self._app_context.push()
-        db.create_all()
+        self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
         admin.set_password("admin-pass")
-        db.session.add(admin)
-        db.session.commit()
+        self.db.session.add(admin)
+        self.db.session.commit()
 
     def tearDown(self) -> None:
-        db.session.remove()
-        db.drop_all()
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
         self._app_context.pop()
         self._temp_dir.cleanup()
         if self._original_flask_debug is None:
             os.environ.pop("FLASK_DEBUG", None)
         else:
             os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
 
     def _login(self) -> None:
         return self.client.post(
@@ -58,7 +66,7 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 302)
 
-        user = AppUser.query.filter_by(username="new-user").first()
+        user = self.AppUser.query.filter_by(username="new-user").first()
         self.assertIsNotNone(user)
         self.assertFalse(user.must_change_password)
 
@@ -76,7 +84,7 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 302)
 
-        user = AppUser.query.filter_by(username="new-user-2").first()
+        user = self.AppUser.query.filter_by(username="new-user-2").first()
         self.assertIsNotNone(user)
         self.assertTrue(user.must_change_password)
 


### PR DESCRIPTION
### Motivation
- Tests were setting `SQLALCHEMY_DATABASE_URI` or loading the app before `DATABASE_URL` was visible to `app.config`, causing inconsistent DB wiring and intermittent sqlite file access errors.
- Scheduler tests were patching the wrong symbol path which raised AttributeError when mocking Twilio.
- Persisting SQLAlchemy engine connections during test teardown could keep temp DB files locked.
- Keep changes small and focused to make tests deterministic and safe to run in CI.

### Description
- In `tests/test_user_creation.py` and `tests/test_password_change.py` set `DATABASE_URL` before importing/reloading `app.config`, then import `create_app`, `db`, and models to ensure config picks up the env var at load time.
- Reworked those tests to use `self.db` and `self.AppUser` and call `self.db.engine.dispose()` during `tearDown()` to release SQLite handles before cleaning temp directories.
- In `tests/test_scheduled_messages.py` set `DATABASE_URL`, reload `app.config` in `setUp()`, and change Twilio mocks to patch `app.services.twilio_service.get_twilio_service` (the actual runtime import path).
- Removed redundant direct `SQLALCHEMY_DATABASE_URI` assignments and ensured config is reloaded where needed to pick up the environment changes.

### Testing
- Ran `pytest` and observed an initial run with failures caused by ordering and wrong patch targets (6 failed), then applied fixes and re-ran `pytest`.
- Final automated test run: `pytest` → `27 passed, 5 warnings`.
- Commands executed: `pytest`, and test files were committed with `git commit` after verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a977e04c8324a9c528f397032c6f)