### PR TITLE
Fix Audience donut overflow by adjusting small chart container and Chart.js layout

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -957,7 +957,17 @@ a:focus-visible {
 }
 
 .chart-container--sm {
-  height: 180px;
+  height: 200px;
+  padding: var(--space-2);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-container--sm canvas {
+  max-width: 100% !important;
+  max-height: 100% !important;
 }
 
 /* Activity Timeline */

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -608,6 +608,9 @@
                 options: {
                     responsive: true,
                     maintainAspectRatio: false,
+                    layout: {
+                        padding: 6
+                    },
                     cutout: '65%',
                     plugins: {
                         legend: { display: false },


### PR DESCRIPTION
### Motivation
- The Audience donut chart could overflow its parent card and extend past the container bounds on some viewports, reducing legibility and breaking layout.
- Adjust the small chart container and Chart.js layout so the donut stays fully visible without materially shrinking it.

### Description
- Updated `.chart-container--sm` in `app/static/css/app.css` to increase height, add padding, use `box-sizing`, center its contents, and constrain the `canvas` with `max-width`/`max-height` rules.
- Added a small `layout.padding` entry to the Chart.js `options` for the audience doughnut in `app/templates/dashboard.html` to keep the chart from touching the edges.
- Changes are purely presentational and do not modify backend logic or data models.

### Testing
- Ran `pytest` for the test suite; result was `27` tests collected with `25 passed` and `2 failed` (the failures are in `tests/test_scheduled_messages.py` and are unrelated to the UI change and caused by missing Twilio credentials in the test environment).
- No new unit tests were added for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960bc58b11c8324a9ec98200f7cb5f7)