### PR TITLE
Handle malformed log detail JSON gracefully

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -959,7 +959,17 @@ def log_detail(log_id):
         flash('Logs are temporarily unavailable due to a schema mismatch.', 'error')
         return redirect(url_for('main.logs_list'))
 
-    details = json.loads(log.details) if log.details else []
+    details = []
+    if log.details:
+        try:
+            details = json.loads(log.details)
+        except json.JSONDecodeError as exc:
+            current_app.logger.warning(
+                'MessageLog details JSON decode failed for log_id=%s: %s',
+                log_id,
+                exc,
+            )
+            details = []
     phones = set()
     for detail in details:
         raw_phone = detail.get('phone') or detail.get('to') or detail.get('recipient')


### PR DESCRIPTION
### Motivation
- Prevent the log detail view from crashing when `MessageLog.details` contains malformed JSON by falling back to an empty details list and surfacing a warning for operators.

### Description
- Wrap `json.loads(log.details)` in a `try/except json.JSONDecodeError` block in `app/routes.py` to log a warning including the `log_id` and use an empty list on decode failure.
- Initialize `details = []` when `log.details` is empty so downstream code still iterates safely.

### Testing
- Ran `pytest` and all tests passed (`31 passed in 8.08s`).
- Commands run during validation: `rg "log_detail" -n app`, `sed -n '900,1040p' app/routes.py`, and `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718e3c2e8c8324be537206722d45b0)