### PR TITLE
Stabilize UNION ordering for unsubscribed list pagination

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1201,7 +1201,7 @@ def unsubscribed_list():
         FROM suppressed_contacts s
         WHERE 1 = 1
         {search_filter_suppressed}
-        ORDER BY created_at DESC
+        ORDER BY created_at DESC, entry_type, id
         LIMIT :limit OFFSET :offset
     """
     combined_query = text(combined_sql).columns(


### PR DESCRIPTION
### Motivation
- The combined `UNION ALL` query in `app/routes.py` previously ordered only by `created_at`, which can yield nondeterministic results when rows share the same timestamp and therefore break pagination stability.

### Description
- Add deterministic tie-breakers to the combined SQL `ORDER BY` in `app/routes.py` by ordering on `created_at DESC, entry_type, id` so the union stream has a stable global ordering.

### Testing
- No automated tests were run; I inspected the modified region with `sed -n '1120,1260p' app/routes.py` and `nl -ba app/routes.py | sed -n '1175,1235p'` and applied the change to `app/routes.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697191c24c8c8324ade0445d4aeddc41)