### PR TITLE
Add shared sortable table behavior

### DIFF
--- a/app/sort_utils.py
+++ b/app/sort_utils.py
@@ -1,0 +1,22 @@
+"""Helpers for validating and normalizing sort parameters."""
+
+from typing import Iterable, Tuple
+
+
+def normalize_sort_params(
+    sort_key: str | None,
+    sort_dir: str | None,
+    allowed_keys: Iterable[str],
+    default_key: str,
+    default_dir: str = "asc",
+) -> Tuple[str, str]:
+    allowed = set(allowed_keys)
+    key = sort_key or ""
+    if key not in allowed:
+        key = default_key
+
+    direction = (sort_dir or default_dir).lower()
+    if direction not in {"asc", "desc"}:
+        direction = default_dir
+
+    return key, direction

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -474,6 +474,50 @@ h6,
   font-weight: 600;
 }
 
+.table th .sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.table th .sort-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.table th .sort-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  opacity: 0.5;
+}
+
+.table th .sort-indicator::before {
+  content: '↕';
+}
+
+.table th .sort-button.is-sorted-asc .sort-indicator,
+.table th .sort-button.is-sorted-desc .sort-indicator {
+  opacity: 0.9;
+}
+
+.table th .sort-button.is-sorted-asc .sort-indicator::before {
+  content: '↑';
+}
+
+.table th .sort-button.is-sorted-desc .sort-indicator::before {
+  content: '↓';
+}
+
 .table td,
 .table th {
   vertical-align: middle;

--- a/app/static/js/table_sort.js
+++ b/app/static/js/table_sort.js
@@ -1,0 +1,236 @@
+(() => {
+  /*
+   * How to add a sortable column:
+   * 1) Add data-sortable="client" (or "server") on the table.
+   * 2) Wrap the header label in a button with data-sort-key and set data-sort-type on the <th>.
+   * 3) (Optional) Add data-sort-value to <td> cells to override the displayed text.
+   */
+  const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+
+  const normalizeNumber = (value) => {
+    if (!value) {
+      return null;
+    }
+    const cleaned = value.replace(/[^\d.-]/g, '');
+    if (!cleaned) {
+      return null;
+    }
+    const parsed = Number(cleaned);
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+
+  const normalizeDate = (value) => {
+    if (!value) {
+      return null;
+    }
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+
+  const normalizePhone = (value) => {
+    if (!value) {
+      return null;
+    }
+    const digits = value.replace(/\D/g, '');
+    if (!digits) {
+      return null;
+    }
+    const parsed = Number(digits);
+    return Number.isNaN(parsed) ? null : parsed;
+  };
+
+  const normalizeValue = (rawValue, type) => {
+    const value = (rawValue ?? '').toString().trim();
+    if (!value) {
+      return { value: null, isEmpty: true };
+    }
+
+    switch (type) {
+      case 'number': {
+        const parsed = normalizeNumber(value);
+        return { value: parsed, isEmpty: parsed === null };
+      }
+      case 'date': {
+        const parsed = normalizeDate(value);
+        return { value: parsed, isEmpty: parsed === null };
+      }
+      case 'phone': {
+        const parsed = normalizePhone(value);
+        return { value: parsed, isEmpty: parsed === null };
+      }
+      case 'enum':
+      case 'string':
+      default:
+        return { value, isEmpty: false };
+    }
+  };
+
+  const compareValues = (aRaw, bRaw, type, direction) => {
+    const a = normalizeValue(aRaw, type);
+    const b = normalizeValue(bRaw, type);
+
+    if (a.isEmpty && b.isEmpty) {
+      return 0;
+    }
+    if (a.isEmpty) {
+      return direction === 'asc' ? 1 : -1;
+    }
+    if (b.isEmpty) {
+      return direction === 'asc' ? -1 : 1;
+    }
+
+    if (type === 'number' || type === 'date' || type === 'phone') {
+      return a.value - b.value;
+    }
+
+    return collator.compare(a.value, b.value);
+  };
+
+  const getCellValue = (cell) => {
+    if (!cell) {
+      return '';
+    }
+    if (cell.dataset.sortValue !== undefined) {
+      return cell.dataset.sortValue;
+    }
+    return cell.textContent.trim();
+  };
+
+  const setSortIndicators = (table, activeTh, direction) => {
+    const headers = table.querySelectorAll('thead th');
+    headers.forEach((th) => {
+      if (!th.dataset.sortType) {
+        return;
+      }
+      th.setAttribute('aria-sort', 'none');
+      const button = th.querySelector('[data-sort-key]');
+      if (button) {
+        button.classList.remove('is-sorted-asc', 'is-sorted-desc');
+      }
+    });
+
+    if (activeTh) {
+      activeTh.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
+      const button = activeTh.querySelector('[data-sort-key]');
+      if (button) {
+        button.classList.toggle('is-sorted-asc', direction === 'asc');
+        button.classList.toggle('is-sorted-desc', direction === 'desc');
+      }
+    }
+  };
+
+  const applyClientSort = (table, th, direction) => {
+    const tbody = table.querySelector('tbody.table-data') || table.tBodies[0];
+    if (!tbody) {
+      return;
+    }
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    if (rows.length <= 1) {
+      return;
+    }
+
+    rows.forEach((row, index) => {
+      if (!row.dataset.sortIndex) {
+        row.dataset.sortIndex = index.toString();
+      }
+    });
+
+    const columnIndex = th.cellIndex;
+    const type = th.dataset.sortType || 'string';
+
+    const sorted = rows
+      .map((row) => ({
+        row,
+        index: Number(row.dataset.sortIndex),
+        value: getCellValue(row.cells[columnIndex]),
+      }))
+      .sort((a, b) => {
+        const compare = compareValues(a.value, b.value, type, direction);
+        if (compare !== 0) {
+          return direction === 'asc' ? compare : -compare;
+        }
+        return a.index - b.index;
+      });
+
+    const fragment = document.createDocumentFragment();
+    sorted.forEach((item) => fragment.appendChild(item.row));
+    tbody.appendChild(fragment);
+  };
+
+  const applyServerSort = (table, th, direction) => {
+    const sortKey = th.querySelector('[data-sort-key]')?.dataset.sortKey;
+    if (!sortKey) {
+      return;
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.set('sort', sortKey);
+    url.searchParams.set('dir', direction);
+    url.searchParams.set('page', '1');
+    window.location.assign(url.toString());
+  };
+
+  const getSortState = (table) => {
+    const url = new URL(window.location.href);
+    const sortKey = url.searchParams.get('sort') || table.dataset.sortDefault || '';
+    const sortDir = url.searchParams.get('dir') || table.dataset.sortDefaultDir || 'asc';
+    return {
+      sortKey,
+      sortDir: sortDir === 'desc' ? 'desc' : 'asc',
+    };
+  };
+
+  const initSortableTable = (table) => {
+    const mode = table.dataset.sortable || 'client';
+    const headers = Array.from(table.querySelectorAll('thead th'));
+
+    headers.forEach((th) => {
+      if (!th.dataset.sortType) {
+        return;
+      }
+      th.setAttribute('aria-sort', 'none');
+      const button = th.querySelector('[data-sort-key]');
+      if (!button) {
+        return;
+      }
+
+      button.addEventListener('click', () => {
+        const key = button.dataset.sortKey || th.cellIndex.toString();
+        const currentKey = table.dataset.sortKey;
+        const currentDir = table.dataset.sortDir || 'asc';
+        const nextDir = currentKey === key && currentDir === 'asc' ? 'desc' : 'asc';
+
+        table.dataset.sortKey = key;
+        table.dataset.sortDir = nextDir;
+        setSortIndicators(table, th, nextDir);
+
+        if (mode === 'server') {
+          applyServerSort(table, th, nextDir);
+        } else {
+          applyClientSort(table, th, nextDir);
+        }
+      });
+    });
+
+    if (mode === 'server') {
+      const { sortKey, sortDir } = getSortState(table);
+      const activeTh = headers.find((th) => th.querySelector('[data-sort-key]')?.dataset.sortKey === sortKey);
+      if (activeTh) {
+        table.dataset.sortKey = sortKey;
+        table.dataset.sortDir = sortDir;
+        setSortIndicators(table, activeTh, sortDir);
+      }
+    }
+  };
+
+  const init = () => {
+    document.querySelectorAll('table[data-sortable]').forEach((table) => {
+      initSortableTable(table);
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -175,6 +175,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="{{ url_for('static', filename='js/table_sort.js') }}"></script>
     <script>
         const toastEls = document.querySelectorAll('.app-toast');
         toastEls.forEach((toastEl) => {

--- a/app/templates/community/list.html
+++ b/app/templates/community/list.html
@@ -59,7 +59,7 @@
     </div>
     {% endif %}
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="communityTable">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="communityTable" data-sortable="client">
             <thead class="table-light">
                 <tr>
                     {% if can_manage_community %}
@@ -69,10 +69,30 @@
                         {% endif %}
                     </th>
                     {% endif %}
-                    <th>Name</th>
-                    <th>Phone</th>
-                    <th>Status</th>
-                    <th>Added</th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="name">
+                            <span>Name</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="phone">
+                        <button type="button" class="sort-button" data-sort-key="phone">
+                            <span>Phone</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="status">
+                            <span>Status</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="added">
+                            <span>Added</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     {% if can_manage_community %}
                     <th width="120">Actions</th>
                     {% endif %}
@@ -88,16 +108,18 @@
                             <input class="form-check-input member-checkbox js-select-row" type="checkbox" name="member_ids" value="{{ member.id }}" form="bulkDeleteForm" aria-label="Select member">
                         </td>
                         {% endif %}
-                        <td>{{ member.name or '-' }}</td>
-                        <td><code>{{ member.phone }}</code></td>
-                        <td>
+                        <td data-sort-value="{{ member.name or '' }}">{{ member.name or '-' }}</td>
+                        <td data-sort-value="{{ member.phone }}"><code>{{ member.phone }}</code></td>
+                        <td data-sort-value="{{ 'Unsubscribed' if is_unsubscribed else 'Active' }}">
                             {% if is_unsubscribed %}
                             <span class="badge bg-secondary">Unsubscribed</span>
                             {% else %}
                             <span class="badge bg-success">Active</span>
                             {% endif %}
                         </td>
-                        <td>{{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}</td>
+                        <td data-sort-value="{{ member.created_at.isoformat() if member.created_at else '' }}">
+                            {{ member.created_at.strftime('%Y-%m-%d') if member.created_at else '-' }}
+                        </td>
                         {% if can_manage_community %}
                         <td>
                             <div class="d-flex flex-wrap gap-1 row-actions">

--- a/app/templates/events/detail.html
+++ b/app/templates/events/detail.html
@@ -74,12 +74,27 @@
                 <h6 class="mb-0"><i class="bi bi-people me-2"></i>Registrations ({{ registrations|length }})</h6>
             </div>
             <div class="table-responsive">
-                <table class="table table-sm mb-0">
+                <table class="table table-sm mb-0" data-sortable="client">
                     <thead class="table-light">
                         <tr>
-                            <th>Name</th>
-                            <th>Phone</th>
-                            <th>Status</th>
+                            <th data-sort-type="string">
+                                <button type="button" class="sort-button" data-sort-key="name">
+                                    <span>Name</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="phone">
+                                <button type="button" class="sort-button" data-sort-key="phone">
+                                    <span>Phone</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="enum">
+                                <button type="button" class="sort-button" data-sort-key="status">
+                                    <span>Status</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
                             <th width="60"></th>
                         </tr>
                     </thead>
@@ -88,9 +103,9 @@
                         {% for reg in registrations %}
                         {% set is_unsubscribed = reg.phone in unsubscribed_phones %}
                         <tr>
-                            <td>{{ reg.name or '-' }}</td>
-                            <td><code>{{ reg.phone }}</code></td>
-                            <td>
+                            <td data-sort-value="{{ reg.name or '' }}">{{ reg.name or '-' }}</td>
+                            <td data-sort-value="{{ reg.phone }}"><code>{{ reg.phone }}</code></td>
+                            <td data-sort-value="{{ 'Unsubscribed' if is_unsubscribed else 'Active' }}">
                                 {% if is_unsubscribed %}
                                 <span class="badge bg-secondary">Unsubscribed</span>
                                 {% else %}

--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -41,7 +41,7 @@
     </div>
     {% endif %}
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="eventsTable">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="eventsTable" data-sortable="client">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -49,10 +49,30 @@
                         <input class="form-check-input" type="checkbox" id="selectAllEvents" aria-label="Select all events">
                         {% endif %}
                     </th>
-                    <th>Title</th>
-                    <th>Date</th>
-                    <th>Registrations</th>
-                    <th>Created</th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="title">
+                            <span>Title</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="date">
+                            <span>Date</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="number">
+                        <button type="button" class="sort-button" data-sort-key="registrations">
+                            <span>Registrations</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="created">
+                            <span>Created</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th width="120">Actions</th>
                 </tr>
             </thead>
@@ -63,16 +83,20 @@
                         <td>
                             <input class="form-check-input js-select-row" type="checkbox" aria-label="Select event">
                         </td>
-                        <td>
+                        <td data-sort-value="{{ event.title }}">
                             <a href="{{ url_for('main.event_detail', event_id=event.id) }}" class="text-decoration-none">
                                 {{ event.title }}
                             </a>
                         </td>
-                        <td>{{ event.date.strftime('%Y-%m-%d') if event.date else '-' }}</td>
-                        <td>
+                        <td data-sort-value="{{ event.date.isoformat() if event.date else '' }}">
+                            {{ event.date.strftime('%Y-%m-%d') if event.date else '-' }}
+                        </td>
+                        <td data-sort-value="{{ event.registrations|length }}">
                             <span class="badge bg-secondary">{{ event.registrations|length }}</span>
                         </td>
-                        <td>{{ event.created_at.strftime('%Y-%m-%d') if event.created_at else '-' }}</td>
+                        <td data-sort-value="{{ event.created_at.isoformat() if event.created_at else '' }}">
+                            {{ event.created_at.strftime('%Y-%m-%d') if event.created_at else '-' }}
+                        </td>
                         <td>
                             <div class="d-flex flex-wrap gap-1 row-actions">
                                 <button type="button" class="btn btn-sm btn-outline-primary" title="Preview"

--- a/app/templates/logs/detail.html
+++ b/app/templates/logs/detail.html
@@ -74,30 +74,55 @@
                 <h6 class="mb-0">Recipient Details</h6>
             </div>
             <div class="table-responsive">
-                <table class="table table-sm mb-0">
+                <table class="table table-sm mb-0" data-sortable="client">
                     <thead class="table-light">
                         <tr>
-                            <th>Name</th>
-                            <th>Phone</th>
-                            <th>Status</th>
-                            <th>Suppression</th>
-                            <th>Error</th>
+                            <th data-sort-type="string">
+                                <button type="button" class="sort-button" data-sort-key="name">
+                                    <span>Name</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="phone">
+                                <button type="button" class="sort-button" data-sort-key="phone">
+                                    <span>Phone</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="enum">
+                                <button type="button" class="sort-button" data-sort-key="status">
+                                    <span>Status</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="enum">
+                                <button type="button" class="sort-button" data-sort-key="suppression">
+                                    <span>Suppression</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th data-sort-type="string">
+                                <button type="button" class="sort-button" data-sort-key="error">
+                                    <span>Error</span>
+                                    <span class="sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
                         {% if details %}
                         {% for d in details %}
                         <tr class="{{ 'table-danger' if not d.success else '' }}">
-                            <td>{{ d.name or '-' }}</td>
-                            <td><code>{{ d.phone }}</code></td>
-                            <td>
+                            <td data-sort-value="{{ d.name or '' }}">{{ d.name or '-' }}</td>
+                            <td data-sort-value="{{ d.phone }}"><code>{{ d.phone }}</code></td>
+                            <td data-sort-value="{{ 'Sent' if d.success else 'Failed' }}">
                                 {% if d.success %}
                                 <span class="badge bg-success">Sent</span>
                                 {% else %}
                                 <span class="badge bg-danger">Failed</span>
                                 {% endif %}
                             </td>
-                            <td>
+                            <td data-sort-value="{{ suppression_status.get(d.normalized_phone) or '' }}">
                                 {% if not d.success and suppression_status.get(d.normalized_phone) %}
                                 <span class="badge bg-warning text-dark text-uppercase">
                                     {{ suppression_status.get(d.normalized_phone) }}
@@ -106,7 +131,7 @@
                                 -
                                 {% endif %}
                             </td>
-                            <td>
+                            <td data-sort-value="{{ d.error or '' }}">
                                 {% if d.error %}
                                 <small class="text-danger">{{ d.error }}</small>
                                 {% else %}

--- a/app/templates/logs/list.html
+++ b/app/templates/logs/list.html
@@ -32,22 +32,44 @@
 
 <div class="card app-card">
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="logsTable">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="logsTable" data-sortable="client">
             <thead class="table-light">
                 <tr>
-                    <th>Date</th>
-                    <th>Target</th>
-                    <th>Message</th>
-                    <th>Results</th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="date">
+                            <span>Date</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="target">
+                            <span>Target</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="message">
+                            <span>Message</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="number">
+                        <button type="button" class="sort-button" data-sort-key="results">
+                            <span>Results</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th width="80"></th>
                 </tr>
             </thead>
             <tbody class="table-data">
                 {% if logs %}
                 {% for log in logs %}
+                {% set target_label = 'Community' if log.target == 'community' else 'Event' %}
+                {% set target_sort = target_label ~ (': ' ~ log.event.title if log.event else '') %}
                 <tr>
-                    <td>{{ log.created_at|localtime }}</td>
-                    <td>
+                    <td data-sort-value="{{ log.created_at.isoformat() if log.created_at else '' }}">{{ log.created_at|localtime }}</td>
+                    <td data-sort-value="{{ target_sort }}">
                         <span class="badge bg-{{ 'primary' if log.target == 'community' else 'info' }}">
                             {{ log.target }}
                         </span>
@@ -55,12 +77,12 @@
                         <br><small class="text-muted">{{ log.event.title }}</small>
                         {% endif %}
                     </td>
-                    <td>
+                    <td data-sort-value="{{ log.message_body }}">
                         <span title="{{ log.message_body }}">
                             {{ log.message_body[:50] }}{% if log.message_body|length > 50 %}...{% endif %}
                         </span>
                     </td>
-                    <td>
+                    <td data-sort-value="{{ log.total_recipients or 0 }}">
                         <div class="mb-1">
                             <span class="badge bg-{% if log.status == 'processing' %}warning{% elif log.status == 'failed' %}danger{% else %}success{% endif %}">
                                 {{ log.status or 'sent' }}
@@ -210,4 +232,3 @@
 </div>
 {% endif %}
 {% endblock %}
-

--- a/app/templates/scheduled/list.html
+++ b/app/templates/scheduled/list.html
@@ -45,15 +45,30 @@
         </div>
     </div>
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledTables" data-bulk-scope="pending">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledTables" data-bulk-scope="pending" data-sortable="client">
             <thead class="table-light">
                 <tr>
                     <th width="40">
                         <input class="form-check-input" type="checkbox" id="selectAllPending" aria-label="Select all pending messages">
                     </th>
-                    <th>Scheduled For</th>
-                    <th>Target</th>
-                    <th>Message</th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="scheduled">
+                            <span>Scheduled For</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="target">
+                            <span>Target</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="message">
+                            <span>Message</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th width="150">Actions</th>
                 </tr>
             </thead>
@@ -63,10 +78,10 @@
                     <td>
                         <input class="form-check-input js-select-row" type="checkbox" aria-label="Select pending message" data-bulk-group="pending">
                     </td>
-                    <td>
+                    <td data-sort-value="{{ msg.scheduled_at.isoformat() if msg.scheduled_at else '' }}">
                         <strong>{{ msg.scheduled_at|localtime }}</strong>
                     </td>
-                    <td>
+                    <td data-sort-value="{% if msg.test_mode %}Test{% elif msg.target == 'community' %}Community{% else %}Event{% endif %}">
                         {% if msg.test_mode %}
                         <span class="badge bg-warning text-dark">TEST</span>
                         {% elif msg.target == 'community' %}
@@ -75,7 +90,7 @@
                         <span class="badge bg-info">Event: {{ msg.event.title if msg.event else 'Unknown' }}</span>
                         {% endif %}
                     </td>
-                    <td>{{ msg.message_body[:80] }}{% if msg.message_body|length > 80 %}...{% endif %}</td>
+                    <td data-sort-value="{{ msg.message_body }}">{{ msg.message_body[:80] }}{% if msg.message_body|length > 80 %}...{% endif %}</td>
                     <td>
                         <div class="d-flex flex-wrap gap-2 row-actions">
                             <button type="button" class="btn btn-sm btn-outline-primary"
@@ -180,16 +195,36 @@
         </div>
     </div>
     <div class="table-responsive d-none d-lg-block">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledPastTable" data-bulk-scope="past">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="scheduledPastTable" data-bulk-scope="past" data-sortable="client">
             <thead class="table-light">
                 <tr>
                     <th width="40">
                         <input class="form-check-input" type="checkbox" id="selectAllPast" aria-label="Select all past messages">
                     </th>
-                    <th>Scheduled For</th>
-                    <th>Status</th>
-                    <th>Target</th>
-                    <th>Message</th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="scheduled">
+                            <span>Scheduled For</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="status">
+                            <span>Status</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="target">
+                            <span>Target</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="message">
+                            <span>Message</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th width="100">Actions</th>
                 </tr>
             </thead>
@@ -199,8 +234,8 @@
                     <td>
                         <input class="form-check-input js-select-row" type="checkbox" aria-label="Select past message" data-bulk-group="past" data-id="{{ msg.id }}">
                     </td>
-                    <td>{{ msg.scheduled_at|localtime }}</td>
-                    <td>
+                    <td data-sort-value="{{ msg.scheduled_at.isoformat() if msg.scheduled_at else '' }}">{{ msg.scheduled_at|localtime }}</td>
+                    <td data-sort-value="{{ msg.status or 'sent' }}">
                         {% if msg.status == 'sent' %}
                         <span class="badge bg-success">Sent</span>
                         {% if msg.message_log and msg.message_log.id %}
@@ -216,14 +251,14 @@
                         <span class="badge bg-secondary">Cancelled</span>
                         {% endif %}
                     </td>
-                    <td>
+                    <td data-sort-value="{{ 'Community' if msg.target == 'community' else 'Event' }}">
                         {% if msg.target == 'community' %}
                         <span class="badge bg-primary">Community</span>
                         {% else %}
                         <span class="badge bg-info">Event</span>
                         {% endif %}
                     </td>
-                    <td>{{ msg.message_body[:50] }}{% if msg.message_body|length > 50 %}...{% endif %}</td>
+                    <td data-sort-value="{{ msg.message_body }}">{{ msg.message_body[:50] }}{% if msg.message_body|length > 50 %}...{% endif %}</td>
                     <td>
                         <div class="d-flex flex-wrap gap-2 row-actions">
                             <button type="button" class="btn btn-sm btn-outline-primary"

--- a/app/templates/unsubscribed/list.html
+++ b/app/templates/unsubscribed/list.html
@@ -42,6 +42,8 @@
                            value="{{ search }}">
                 </div>
             </div>
+            <input type="hidden" name="sort" value="{{ sort_key }}">
+            <input type="hidden" name="dir" value="{{ sort_dir }}">
         </form>
     </div>
 </div>
@@ -64,7 +66,7 @@
         </form>
     </div>
     <div class="table-responsive">
-        <table class="table table-hover table-sticky-header mb-0 table-loading" id="unsubscribedTable">
+        <table class="table table-hover table-sticky-header mb-0 table-loading" id="unsubscribedTable" data-sortable="server" data-sort-default="created_at" data-sort-default-dir="desc">
             <thead class="table-light">
                 <tr>
                     <th width="40">
@@ -72,12 +74,42 @@
                         <input class="form-check-input" type="checkbox" id="selectAllEntries" aria-label="Select all entries">
                         {% endif %}
                     </th>
-                    <th>Name</th>
-                    <th>Phone</th>
-                    <th>Reason</th>
-                    <th>Category</th>
-                    <th>Source</th>
-                    <th>Added</th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="name">
+                            <span>Name</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="phone">
+                        <button type="button" class="sort-button" data-sort-key="phone">
+                            <span>Phone</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="reason">
+                            <span>Reason</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="category">
+                            <span>Category</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="source">
+                            <span>Source</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="created_at">
+                            <span>Added</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     {% if can_manage_unsubscribed %}
                     <th width="80">Actions</th>
                     {% endif %}
@@ -94,14 +126,14 @@
                             <input class="form-check-input entry-checkbox" type="checkbox" name="suppressed_ids" value="{{ entry.id }}" form="bulkDeleteForm" aria-label="Select entry">
                             {% endif %}
                         </td>
-                        <td>{{ entry.name or '-' }}</td>
-                        <td><code>{{ entry.phone }}</code></td>
-                        <td>{{ entry.reason or '-' }}</td>
-                        <td>
+                        <td data-sort-value="{{ entry.name or '' }}">{{ entry.name or '-' }}</td>
+                        <td data-sort-value="{{ entry.phone }}"><code>{{ entry.phone }}</code></td>
+                        <td data-sort-value="{{ entry.reason or '' }}">{{ entry.reason or '-' }}</td>
+                        <td data-sort-value="{{ entry.category }}">
                             <span class="badge bg-light text-dark text-uppercase">{{ entry.category }}</span>
                         </td>
-                        <td><span class="badge bg-light text-dark">{{ entry.source or '-' }}</span></td>
-                        <td>{{ entry.created_at.strftime('%Y-%m-%d') if entry.created_at else '-' }}</td>
+                        <td data-sort-value="{{ entry.source or '' }}"><span class="badge bg-light text-dark">{{ entry.source or '-' }}</span></td>
+                        <td data-sort-value="{{ entry.created_at.isoformat() if entry.created_at else '' }}">{{ entry.created_at.strftime('%Y-%m-%d') if entry.created_at else '-' }}</td>
                         {% if can_manage_unsubscribed %}
                         <td>
                             {% if entry.entry_type == 'unsubscribed' %}
@@ -155,7 +187,7 @@
         <nav aria-label="Suppression list pagination">
             <ul class="pagination pagination-sm mb-0">
                 <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-                    <a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=page-1) }}" aria-label="Previous">
+                    <a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=page-1, sort=sort_key, dir=sort_dir) }}" aria-label="Previous">
                         <span aria-hidden="true">&laquo;</span>
                     </a>
                 </li>
@@ -163,13 +195,13 @@
                     {% if p == page %}
                     <li class="page-item active"><span class="page-link">{{ p }}</span></li>
                     {% elif p == 1 or p == total_pages or (p >= page - 2 and p <= page + 2) %}
-                    <li class="page-item"><a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=p) }}">{{ p }}</a></li>
+                    <li class="page-item"><a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=p, sort=sort_key, dir=sort_dir) }}">{{ p }}</a></li>
                     {% elif p == page - 3 or p == page + 3 %}
                     <li class="page-item disabled"><span class="page-link">...</span></li>
                     {% endif %}
                 {% endfor %}
                 <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
-                    <a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=page+1) }}" aria-label="Next">
+                    <a class="page-link" href="{{ url_for('main.unsubscribed_list', search=search, page=page+1, sort=sort_key, dir=sort_dir) }}" aria-label="Next">
                         <span aria-hidden="true">&raquo;</span>
                     </a>
                 </li>

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -17,12 +17,27 @@
 {% block content %}
 <div class="card app-card">
     <div class="table-responsive">
-        <table class="table table-hover mb-0">
+        <table class="table table-hover mb-0" data-sortable="client">
             <thead class="table-light">
                 <tr>
-                    <th>Username</th>
-                    <th>Role</th>
-                    <th>Created</th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="username">
+                            <span>Username</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="enum">
+                        <button type="button" class="sort-button" data-sort-key="role">
+                            <span>Role</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
+                    <th data-sort-type="date">
+                        <button type="button" class="sort-button" data-sort-key="created">
+                            <span>Created</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th width="140">Actions</th>
                 </tr>
             </thead>
@@ -30,18 +45,20 @@
                 {% if users %}
                     {% for user in users %}
                     <tr>
-                        <td>
+                        <td data-sort-value="{{ user.username }}">
                             {{ user.username }}
                             {% if current_user.id == user.id %}
                                 <span class="badge bg-secondary ms-2">You</span>
                             {% endif %}
                         </td>
-                        <td>
+                        <td data-sort-value="{{ 'Admin' if user.is_admin else 'Social Media Manager' }}">
                             <span class="badge bg-{{ 'primary' if user.is_admin else 'info' }}">
                                 {{ 'Admin' if user.is_admin else 'Social Media Manager' }}
                             </span>
                         </td>
-                        <td>{{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '-' }}</td>
+                        <td data-sort-value="{{ user.created_at.isoformat() if user.created_at else '' }}">
+                            {{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '-' }}
+                        </td>
                         <td>
                             <div class="d-flex flex-wrap gap-1">
                                 <a href="{{ url_for('main.users_edit', user_id=user.id) }}" class="btn btn-sm btn-outline-secondary">

--- a/tests/test_sort_utils.py
+++ b/tests/test_sort_utils.py
@@ -1,0 +1,55 @@
+import unittest
+
+from app.sort_utils import normalize_sort_params
+
+
+class TestNormalizeSortParams(unittest.TestCase):
+    def test_defaults_to_known_key_and_direction(self) -> None:
+        key, direction = normalize_sort_params(
+            None,
+            None,
+            allowed_keys={"name", "created_at"},
+            default_key="created_at",
+            default_dir="desc",
+        )
+
+        self.assertEqual(key, "created_at")
+        self.assertEqual(direction, "desc")
+
+    def test_rejects_unknown_key(self) -> None:
+        key, direction = normalize_sort_params(
+            "bogus",
+            "asc",
+            allowed_keys={"name", "created_at"},
+            default_key="name",
+        )
+
+        self.assertEqual(key, "name")
+        self.assertEqual(direction, "asc")
+
+    def test_normalizes_direction(self) -> None:
+        key, direction = normalize_sort_params(
+            "name",
+            "DESC",
+            allowed_keys={"name"},
+            default_key="name",
+        )
+
+        self.assertEqual(key, "name")
+        self.assertEqual(direction, "desc")
+
+    def test_invalid_direction_falls_back(self) -> None:
+        key, direction = normalize_sort_params(
+            "name",
+            "sideways",
+            allowed_keys={"name"},
+            default_key="name",
+            default_dir="asc",
+        )
+
+        self.assertEqual(key, "name")
+        self.assertEqual(direction, "asc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a single, reusable sorting layer so every UI table/list with labeled columns behaves consistently when users click headers. 
- Ensure sorting is type-aware (strings, numbers, dates, phones, enums), stable, accessible, and supports client- and server-side modes where appropriate.

### Description
- Added a small client-side sorter `app/static/js/table_sort.js` and CSS indicators in `app/static/css/app.css`, and included the script in `app/templates/base.html` to enable header buttons with `aria-sort` and visible arrows. 
- Updated table templates to opt-in: headers now use a button with `data-sort-key` and `<th>`s use `data-sort-type`, cells may include `data-sort-value` for canonical access; changed tables in `community`, `events`, `scheduled`, `logs`, `users`, `events/detail`, and `logs/detail` to use the new patterns. 
- Implemented server-side sorting for the suppression list (`/unsubscribed`) with `app/sort_utils.py` to validate/normalize `sort`/`dir` params and SQL ordering that handles phone normalization and consistent null ordering; templates preserve `sort`/`dir` across pagination. 
- Added unit tests `tests/test_sort_utils.py` for sort param normalization and kept changes small/iterative; files changed: `app/static/js/table_sort.js`, `app/static/css/app.css`, `app/sort_utils.py`, `app/routes.py`, `app/templates/*` (multiple list/detail templates), and `tests/test_sort_utils.py`.
- How to add a new sortable column: mark the table with `data-sortable="client"` or `"server"`, set `data-sort-type` on the `<th>`, wrap the visible label in a button with `data-sort-key`, and (optional) set `data-sort-value` on cells to provide a canonical accessor or ISO value for dates/phones.

### Testing
- Ran unit tests with `pytest` and all tests passed: `35 passed` (see test run). 
- Started the dev server (`flask --app wsgi:app run --debug`) and performed a quick smoke test including a headless browser screenshot of the Community page to verify headers and script load. 
- Commands run: `pytest`, `flask --app wsgi:app run --debug`, and a small Playwright script to load `/community` and capture a screenshot; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b18008948324bcf0153ba6614b4a)