### PR TITLE
Fix phone sort cast for unsubscribed list

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1184,7 +1184,7 @@ def unsubscribed_list():
     offset = (page - 1) * per_page
     sql_params.update({'limit': per_page, 'offset': offset})
     phone_sort_expr = (
-        "CAST(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(phone, '+', ''), '(', ''), ')', ''), '-', ''), ' ', ''), '.', '') AS INTEGER)"
+        "CAST(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(phone, '+', ''), '(', ''), ')', ''), '-', ''), ' ', ''), '.', '') AS BIGINT)"
     )
     sort_config = {
         'name': {'expr': 'LOWER(name)', 'null_check': 'name'},


### PR DESCRIPTION
### Motivation
- Prevent 32-bit integer overflow when sorting phone numbers in the unsubscribed/suppressed list by ensuring the stripped phone digits are cast to a sufficiently large numeric type.

### Description
- Update `phone_sort_expr` in `app/routes.py` to cast the stripped phone digits to `BIGINT` instead of `INTEGER` so E.164 numbers do not cause an out-of-range error.

### Testing
- No automated tests were run for this change; this is a minimal type fix and should be validated by running `pytest` and exercising the `/unsubscribed` phone sort in staging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b80678f08324ac12ade1be6d6a15)