### PR TITLE
Improve mobile nav and search contrast

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -284,13 +284,13 @@ h6,
 
 .app-search .form-control {
   padding-left: calc(var(--space-3) * 2 + 0.5rem);
-  background-color: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #fff;
+  background-color: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
 }
 
 .app-search .form-control::placeholder {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--color-text-muted);
 }
 
 .app-sidebar .app-search i {
@@ -1871,12 +1871,14 @@ tr:hover .row-actions,
     padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));
   }
 
-  /* Hide the hamburger menu collapse when bottom nav is present */
-  .app-mobile-nav-panel .nav {
-    display: none;
-  }
-
   .app-mobile-nav-panel {
     padding: var(--space-3) !important;
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+  }
+
+  .app-mobile-nav-panel .nav {
+    display: flex;
+    gap: var(--space-1);
   }
 }


### PR DESCRIPTION
### Motivation
- Fix mobile navigation cutoff and improve search input contrast because the bottom "More" panel hid links and the search input used white text on a light background, making mobile UX confusing.

### Description
- Update `app/static/css/app.css` to make `.app-search .form-control` use `var(--color-surface-muted)` background, `var(--color-border)` border, `var(--color-text)` text and `var(--color-text-muted)` placeholder, and change the mobile panel so `.app-mobile-nav-panel` has `max-height`/`overflow-y: auto` and `.app-mobile-nav-panel .nav` is visible and scrollable.

### Testing
- Ran `pytest` which succeeded (`36 passed`), and ran `python -m app.dbdoctor --print` and `python -m app.dbdoctor --apply` which failed with `unable to open database file` in this environment (not a change regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971c69bf9c08324b45efa035c503b4e)