### PR TITLE
Simplify mobile navigation to hamburger menu

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1808,69 +1808,7 @@ tr:hover .row-actions,
   }
 }
 
-/* 3. Bottom Navigation Bar (Mobile) */
-.app-bottom-nav {
-  display: none;
-}
-
 @media (max-width: 991.98px) {
-  .app-bottom-nav {
-    display: flex;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: var(--color-surface);
-    border-top: 1px solid var(--color-border);
-    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.08);
-    z-index: 1050;
-    padding: var(--space-1) 0;
-    padding-bottom: calc(var(--space-1) + env(safe-area-inset-bottom, 0));
-  }
-
-  .app-bottom-nav__link {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: var(--space-2) var(--space-1);
-    color: var(--color-text-muted);
-    text-decoration: none;
-    font-size: 0.625rem;
-    font-weight: 500;
-    gap: 2px;
-    min-height: 56px;
-    transition: color 0.15s ease;
-  }
-
-  .app-bottom-nav__link i {
-    font-size: 1.25rem;
-    transition: transform 0.15s ease;
-  }
-
-  .app-bottom-nav__link:hover,
-  .app-bottom-nav__link:focus {
-    color: var(--color-primary);
-  }
-
-  .app-bottom-nav__link.active {
-    color: var(--color-primary);
-  }
-
-  .app-bottom-nav__link.active i {
-    transform: scale(1.1);
-  }
-
-  /* Add bottom padding to main content to prevent overlap with bottom nav */
-  .app-content {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));
-  }
-
-  .app-footer {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom, 0));
-  }
-
   .app-mobile-nav-panel {
     padding: var(--space-3) !important;
     max-height: calc(100vh - 140px);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -173,31 +173,6 @@
         </div>
     </div>
 
-    {% if current_user.is_authenticated %}
-    <nav class="app-bottom-nav" aria-label="Mobile navigation">
-        <a class="app-bottom-nav__link {% if request.endpoint == 'main.dashboard' %}active{% endif %}" href="{{ url_for('main.dashboard') }}">
-            <i class="bi bi-send{% if request.endpoint == 'main.dashboard' %}-fill{% endif %}"></i>
-            <span>Send</span>
-        </a>
-        <a class="app-bottom-nav__link {% if 'community' in request.endpoint %}active{% endif %}" href="{{ url_for('main.community_list') }}">
-            <i class="bi bi-people{% if 'community' in request.endpoint %}-fill{% endif %}"></i>
-            <span>Community</span>
-        </a>
-        <a class="app-bottom-nav__link {% if 'event' in request.endpoint %}active{% endif %}" href="{{ url_for('main.events_list') }}">
-            <i class="bi bi-calendar-event{% if 'event' in request.endpoint %}-fill{% endif %}"></i>
-            <span>Events</span>
-        </a>
-        <a class="app-bottom-nav__link {% if logs_active %}active{% endif %}" href="{{ url_for('main.logs_list') }}">
-            <i class="bi bi-journal-text"></i>
-            <span>Logs</span>
-        </a>
-        <a class="app-bottom-nav__link" href="#" data-bs-toggle="collapse" data-bs-target="#appMobileNav" aria-expanded="false">
-            <i class="bi bi-three-dots"></i>
-            <span>More</span>
-        </a>
-    </nav>
-    {% endif %}
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="{{ url_for('static', filename='js/table_sort.js') }}"></script>


### PR DESCRIPTION
### Motivation
- Reduce redundant mobile navigation patterns by using a single, expandable hamburger menu instead of both a persistent bottom bar and a topbar collapse.
- Improve clarity on small screens and avoid competing navigation affordances that can confuse users.

### Description
- Remove the bottom navigation markup from `app/templates/base.html` so mobile screens use the existing topbar hamburger (`#appMobileNav`) collapse only.
- Strip the bottom-nav-specific CSS rules from `app/static/css/app.css` and keep the mobile nav panel sizing/scroll behavior intact for the hamburger experience.
- Change is minimal and purely presentational; no backend logic or route changes were made.

### Testing
- Ran unit tests with `pytest` (command: `source venv/bin/activate && pytest`) and all tests passed: `36 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729a4afc34832492a4b0317261c4d1)