### PR TITLE
Fix CSP-safe confirmation handler for event registrations

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,0 +1,16 @@
+document.addEventListener('click', (event) => {
+    const confirmTarget = event.target.closest('[data-confirm]');
+    if (!confirmTarget) {
+        return;
+    }
+
+    const message = confirmTarget.dataset.confirm;
+    if (!message) {
+        return;
+    }
+
+    if (!window.confirm(message)) {
+        event.preventDefault();
+        event.stopPropagation();
+    }
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -197,6 +197,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="{{ url_for('static', filename='js/table_sort.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script>
         const toastEls = document.querySelectorAll('.app-toast');
         toastEls.forEach((toastEl) => {

--- a/app/templates/events/detail.html
+++ b/app/templates/events/detail.html
@@ -119,7 +119,7 @@
                                         <i class="bi bi-person-x"></i>
                                     </button>
                                     {% endif %}
-                                    <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" title="Remove" aria-label="Remove registration" onclick="return confirm('Remove this registration?');">
+                                    <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" title="Remove" aria-label="Remove registration" data-confirm="Remove this registration?">
                                         <i class="bi bi-x"></i>
                                     </button>
                                 </div>
@@ -168,7 +168,7 @@
                                 <i class="bi bi-person-x"></i> Unsubscribe
                             </button>
                             {% endif %}
-                            <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" aria-label="Remove registration" onclick="return confirm('Remove this registration?');">
+                            <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" aria-label="Remove registration" data-confirm="Remove this registration?">
                                 <i class="bi bi-x"></i> Remove
                             </button>
                         </div>


### PR DESCRIPTION
### Motivation
- Inline `onclick=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a300e0d08324b20aab9ae68c8efa)