### PR TITLE
Replace inline confirm handlers with data-confirm

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -210,6 +210,19 @@
             });
         });
 
+        document.addEventListener('click', (event) => {
+            const confirmTrigger = event.target.closest('[data-confirm]');
+            if (!confirmTrigger) {
+                return;
+            }
+
+            const confirmMessage = confirmTrigger.getAttribute('data-confirm') || 'Are you sure?';
+            if (!window.confirm(confirmMessage)) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+        });
+
         const iconEls = document.querySelectorAll('i.bi');
         iconEls.forEach((iconEl) => {
             iconEl.setAttribute('aria-hidden', 'true');

--- a/app/templates/events/detail.html
+++ b/app/templates/events/detail.html
@@ -119,7 +119,7 @@
                                         <i class="bi bi-person-x"></i>
                                     </button>
                                     {% endif %}
-                                    <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" title="Remove" aria-label="Remove registration" onclick="return confirm('Remove this registration?');">
+                                    <button type="submit" form="remove-reg-{{ reg.id }}" class="btn btn-sm btn-outline-danger" title="Remove" aria-label="Remove registration" data-confirm="Remove this registration?">
                                         <i class="bi bi-x"></i>
                                     </button>
                                 </div>

--- a/app/templates/inbox/keywords_list.html
+++ b/app/templates/inbox/keywords_list.html
@@ -63,7 +63,7 @@
                                 <form method="POST" action="{{ url_for('main.keyword_rule_delete', rule_id=rule.id) }}">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <button class="btn btn-sm btn-outline-danger" type="submit"
-                                            onclick="return confirm('Delete this keyword rule?');">
+                                            data-confirm="Delete this keyword rule?">
                                         <i class="bi bi-trash"></i>
                                     </button>
                                 </form>

--- a/app/templates/inbox/surveys_list.html
+++ b/app/templates/inbox/surveys_list.html
@@ -71,7 +71,7 @@
                                 <form method="POST" action="{{ url_for('main.survey_flow_deactivate', survey_id=survey.id) }}">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <button class="btn btn-sm btn-outline-warning" type="submit"
-                                            onclick="return confirm('Deactivate this survey flow?');">
+                                            data-confirm="Deactivate this survey flow?">
                                         <i class="bi bi-pause-circle"></i>
                                     </button>
                                 </form>


### PR DESCRIPTION
## Summary
- add a centralized data-confirm handler in `base.html` to prompt users consistently
- update event detail, keyword rule, and survey flow buttons to use `data-confirm`

## Testing
- Not run (not requested)