### PR TITLE
Guard survey keyword conflict check to only run when keyword changes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1789,7 +1789,7 @@ def keyword_rule_edit(rule_id):
         if existing:
             flash('That keyword already exists.', 'error')
             return render_template('inbox/keyword_form.html', rule=rule, form_data=None)
-        if _keyword_conflicts_with_survey(normalized_keyword):
+        if normalized_keyword != rule.keyword and _keyword_conflicts_with_survey(normalized_keyword):
             flash('That keyword is already used as a survey trigger.', 'error')
             return render_template('inbox/keyword_form.html', rule=rule, form_data=None)
 


### PR DESCRIPTION
### Motivation
- Prevent edits to an existing keyword automation from being blocked by pre-existing survey trigger conflicts when the rule's keyword itself is not being changed.

### Description
- In `app/routes.py` modify the `keyword_rule_edit` flow so the `_keyword_conflicts_with_survey` check only runs when `normalized_keyword != rule.keyword` before rejecting the edit.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5f7b87883248c1787b9484e03d2)