### PR TITLE
Fix keyword conflict normalization across legacy spacing

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -64,23 +64,25 @@ def _is_safe_url(target):
 
 
 def _keyword_conflicts_with_survey(trigger_keyword: str, *, exclude_survey_id: int | None = None) -> bool:
-    normalized_trigger = db.func.upper(db.func.trim(trigger_keyword))
-    query = SurveyFlow.query.filter(
-        db.func.upper(db.func.trim(SurveyFlow.trigger_keyword)) == normalized_trigger
-    )
+    normalized_trigger = normalize_keyword(trigger_keyword)
+    query = SurveyFlow.query
     if exclude_survey_id is not None:
         query = query.filter(SurveyFlow.id != exclude_survey_id)
-    return query.first() is not None
+    return any(
+        normalize_keyword(survey.trigger_keyword) == normalized_trigger
+        for survey in query.all()
+    )
 
 
 def _keyword_conflicts_with_rule(keyword: str, *, exclude_rule_id: int | None = None) -> bool:
-    normalized_keyword = db.func.upper(db.func.trim(keyword))
-    query = KeywordAutomationRule.query.filter(
-        db.func.upper(db.func.trim(KeywordAutomationRule.keyword)) == normalized_keyword
-    )
+    normalized_keyword = normalize_keyword(keyword)
+    query = KeywordAutomationRule.query
     if exclude_rule_id is not None:
         query = query.filter(KeywordAutomationRule.id != exclude_rule_id)
-    return query.first() is not None
+    return any(
+        normalize_keyword(rule.keyword) == normalized_keyword
+        for rule in query.all()
+    )
 
 
 # Health check endpoint


### PR DESCRIPTION
### Motivation
- The DB-side `UPPER(TRIM(...))` comparison did not match the app's `normalize_keyword()` which collapses internal whitespace, allowing duplicates when legacy values contain extra spaces.
- Make conflict checks use the same normalization used for persisted values so incoming forms cannot bypass uniqueness checks due to spacing differences.

### Description
- Replaced the SQL-side normalization in `_keyword_conflicts_with_survey` and `_keyword_conflicts_with_rule` with application-level `normalize_keyword` comparisons. 
- The functions now query the relevant rows (honoring `exclude_survey_id` / `exclude_rule_id`) and compare `normalize_keyword(stored_value)` to the normalized input. 
- Change is minimal and limited to `app/routes.py` and uses the existing `normalize_keyword` from `app.services.inbox_service` so no new dependencies were added.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c82b18388324ba81c024083e4f1a)