### PR TITLE
Fix confirm handlers and refresh logic for dashboard and lists

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,16 +1,15 @@
-document.addEventListener('click', (event) => {
-    const confirmTarget = event.target.closest('[data-confirm]');
-    if (!confirmTarget) {
-        return;
-    }
+if (!window.__dataConfirmHandlerBound) {
+    window.__dataConfirmHandlerBound = true;
 
-    const message = confirmTarget.dataset.confirm;
-    if (!message) {
-        return;
-    }
+    document.addEventListener('click', (event) => {
+        const confirmTarget = event.target.closest('[data-confirm]');
+        if (!confirmTarget) {
+            return;
+        }
 
-    if (!window.confirm(message)) {
-        event.preventDefault();
-        event.stopPropagation();
-    }
-});
+        const message = confirmTarget.dataset.confirm || 'Are you sure?';
+        if (!window.confirm(message)) {
+            event.preventDefault();
+        }
+    });
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -219,18 +219,6 @@
             });
         });
 
-        document.addEventListener('click', (event) => {
-            const confirmTrigger = event.target.closest('[data-confirm]');
-            if (!confirmTrigger) {
-                return;
-            }
-
-            const confirmMessage = confirmTrigger.getAttribute('data-confirm') || 'Are you sure?';
-            if (!window.confirm(confirmMessage)) {
-                event.preventDefault();
-            }
-        });
-
         const iconEls = document.querySelectorAll('i.bi');
         iconEls.forEach((iconEl) => {
             iconEl.setAttribute('aria-hidden', 'true');

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -438,7 +438,10 @@
                 const existingTimezone = getCookieValue('client_timezone');
                 if (existingTimezone !== resolvedTimezone) {
                     document.cookie = `client_timezone=${encodeURIComponent(resolvedTimezone)}; path=/; max-age=31536000; samesite=lax`;
-                    window.location.reload();
+                    const updatedTimezone = getCookieValue('client_timezone');
+                    if (updatedTimezone === resolvedTimezone) {
+                        window.location.reload();
+                    }
                 }
             }
         } catch (e) {

--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -272,8 +272,12 @@
     const selectAllEvents = document.getElementById('selectAllEvents');
     const bulkSelectionActions = document.getElementById('bulkSelectionActions');
 
+    function isVisible(element) {
+        return element.offsetParent !== null;
+    }
+
     function getEventCheckboxes() {
-        return Array.from(document.querySelectorAll('.js-select-row'));
+        return Array.from(document.querySelectorAll('.js-select-row')).filter(isVisible);
     }
 
     function updateBulkUi() {
@@ -316,7 +320,10 @@
         });
     }
 
-    getEventCheckboxes().forEach(b => b.addEventListener('change', updateBulkUi));
+    document.querySelectorAll('.js-select-row').forEach((box) => {
+        box.addEventListener('change', updateBulkUi);
+    });
+    window.addEventListener('resize', updateBulkUi);
     updateBulkUi();
 </script>
 {% endblock %}

--- a/app/templates/scheduled/list.html
+++ b/app/templates/scheduled/list.html
@@ -420,6 +420,7 @@
     
     const pendingIdsContainer = document.getElementById('pendingIdsContainer');
     let currentPendingIds = [];
+    const statusEndpoint = `/scheduled/status${window.location.search || ''}`;
     if (pendingIdsContainer && pendingIdsContainer.dataset && pendingIdsContainer.dataset.pendingIds) {
         try {
             currentPendingIds = JSON.parse(pendingIdsContainer.dataset.pendingIds);
@@ -430,9 +431,10 @@
     
     async function checkStatus() {
         try {
-            const response = await fetch('/scheduled/status');
+            const response = await fetch(statusEndpoint);
             if (!response.ok) return;
             const data = await response.json();
+            if (!Array.isArray(data.pending_ids)) return;
             
             const currentSorted = currentPendingIds.slice().sort((a,b) => a-b).join(',');
             const newSorted = data.pending_ids.slice().sort((a,b) => a-b).join(',');

--- a/tests/test_inbox_automation_routes.py
+++ b/tests/test_inbox_automation_routes.py
@@ -172,7 +172,7 @@ class TestInboxAutomationRouteValidation(unittest.TestCase):
 
         response = self.client.get("/inbox/keywords")
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'data-confirm="Delete this keyword rule?"', response.data)
+        self.assertGreaterEqual(response.data.count(b'data-confirm="Delete this keyword rule?"'), 2)
         self.assertNotIn(b"onclick=\"return confirm('Delete this keyword rule?');\"", response.data)
 
     def test_surveys_list_uses_data_confirm_attribute(self) -> None:
@@ -181,7 +181,7 @@ class TestInboxAutomationRouteValidation(unittest.TestCase):
 
         response = self.client.get("/inbox/surveys")
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'data-confirm="Deactivate this survey flow?"', response.data)
+        self.assertGreaterEqual(response.data.count(b'data-confirm="Deactivate this survey flow?"'), 2)
         self.assertNotIn(b"onclick=\"return confirm('Deactivate this survey flow?');\"", response.data)
 
     def test_base_confirm_handler_does_not_stop_immediate_propagation(self) -> None:
@@ -189,7 +189,8 @@ class TestInboxAutomationRouteValidation(unittest.TestCase):
 
         response = self.client.get("/dashboard")
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"document.addEventListener('click'", response.data)
+        self.assertIn(b"/static/js/app.js", response.data)
+        self.assertNotIn(b"const confirmTrigger = event.target.closest('[data-confirm]')", response.data)
         self.assertNotIn(b"stopImmediatePropagation", response.data)
 
 

--- a/tests/test_scheduled_routes.py
+++ b/tests/test_scheduled_routes.py
@@ -1,0 +1,130 @@
+import importlib
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+
+class TestScheduledStatusFiltering(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, Event, ScheduledMessage
+
+        self.db = db
+        self.AppUser = AppUser
+        self.Event = Event
+        self.ScheduledMessage = ScheduledMessage
+
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin.set_password("admin-pass")
+        self.db.session.add(admin)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self) -> None:
+        response = self.client.post(
+            "/login",
+            data={"username": "admin", "password": "admin-pass"},
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def _create_scheduled(
+        self,
+        *,
+        message_body: str,
+        status: str = "pending",
+        target: str = "community",
+        event_id: int | None = None,
+    ):
+        msg = self.ScheduledMessage(
+            message_body=message_body,
+            status=status,
+            target=target,
+            event_id=event_id,
+            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(minutes=5),
+            test_mode=False,
+        )
+        self.db.session.add(msg)
+        self.db.session.commit()
+        return msg
+
+    def test_scheduled_status_returns_all_pending_without_search(self) -> None:
+        self._login()
+        keep_one = self._create_scheduled(message_body="Alpha pending")
+        keep_two = self._create_scheduled(message_body="Beta pending")
+        self._create_scheduled(message_body="Past message", status="sent")
+
+        response = self.client.get("/scheduled/status")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.get_json()
+        self.assertEqual(set(payload["pending_ids"]), {keep_one.id, keep_two.id})
+        self.assertEqual(payload["pending_count"], 2)
+
+    def test_scheduled_status_filters_pending_ids_by_message_search(self) -> None:
+        self._login()
+        match = self._create_scheduled(message_body="Spring Gala invite")
+        self._create_scheduled(message_body="Board reminder")
+
+        response = self.client.get("/scheduled/status?search=gala")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.get_json()
+        self.assertEqual(payload["pending_ids"], [match.id])
+        self.assertEqual(payload["pending_count"], 1)
+
+    def test_scheduled_status_filters_pending_ids_by_event_title(self) -> None:
+        self._login()
+        event = self.Event(title="Neighborhood Cleanup")
+        self.db.session.add(event)
+        self.db.session.commit()
+
+        match = self._create_scheduled(
+            message_body="Reminder",
+            target="event",
+            event_id=event.id,
+        )
+        self._create_scheduled(message_body="Community hello", target="community")
+
+        response = self.client.get("/scheduled/status?search=cleanup")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.get_json()
+        self.assertEqual(payload["pending_ids"], [match.id])
+        self.assertEqual(payload["pending_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- deduplicate document-level `[data-confirm]` handlers to avoid double prompts on destructive actions
- switch mobile automations to centralized confirm handling and resolve select-all accounting issues for bulk events
- prevent refresh loops on scheduled pages with active filters and dashboards when timezone cookies can’t persist

## Testing
- Not run (not requested)