### PR TITLE
Audit and update inbox UI selection states

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -21,6 +21,12 @@
   --color-text-muted: #64748b;
 
   --color-focus: #6366f1;
+  --inbox-thread-active-bg: #e8edff;
+  --inbox-thread-active-border: #4f46e5;
+  --inbox-thread-active-text: #1f2a44;
+  --inbox-thread-active-meta: #334155;
+  --inbox-thread-hover-bg: #f4f6ff;
+  --inbox-error-on-primary-text: #fef3c7;
 
   --gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
   --gradient-success: linear-gradient(135deg, #10b981 0%, #06b6d4 100%);
@@ -687,34 +693,177 @@ h6,
   overflow-y: auto;
 }
 
+.inbox-layout-loading {
+  cursor: progress;
+}
+
+.inbox-thread-list-skeleton,
+.inbox-message-pane-skeleton {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.inbox-skeleton-line {
+  height: 0.7rem;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%);
+  background-size: 200% 100%;
+  animation: inbox-skeleton-shimmer 1.1s ease-in-out infinite;
+}
+
+.inbox-skeleton-line--title {
+  height: 0.9rem;
+  width: min(70%, 12rem);
+}
+
+.inbox-skeleton-line--short {
+  width: 55%;
+}
+
+@keyframes inbox-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
 .inbox-thread-item {
-  border-left: 3px solid transparent;
+  border-left: 4px solid transparent;
   padding: var(--space-3) var(--space-4);
+  background-color: var(--color-surface);
+  transition: background-color var(--motion-duration-fast, 160ms) var(--motion-ease-standard, ease), border-color var(--motion-duration-fast, 160ms) var(--motion-ease-standard, ease), box-shadow var(--motion-duration-fast, 160ms) var(--motion-ease-standard, ease);
+}
+
+.inbox-thread-item:hover,
+.inbox-thread-item:focus-within {
+  background-color: var(--inbox-thread-hover-bg);
 }
 
 .inbox-thread-item.active {
-  border-left-color: var(--color-primary);
-  background-color: rgba(99, 102, 241, 0.08);
+  border-left-color: var(--inbox-thread-active-border);
+  background-color: var(--inbox-thread-active-bg);
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.18);
+}
+
+.inbox-thread-item.active:focus-within {
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.18), 0 0 0 2px rgba(79, 70, 229, 0.2);
+}
+
+.inbox-thread-link {
+  color: var(--color-text);
+}
+
+.inbox-thread-link:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.inbox-thread-item.active .inbox-thread-link {
+  color: var(--inbox-thread-active-text);
 }
 
 .inbox-thread-item .fw-semibold {
-  color: var(--color-text);
+  color: inherit;
   font-size: var(--font-size-3);
 }
 
+.inbox-thread-phone,
 .inbox-thread-preview {
   color: var(--color-text-muted);
-  line-height: 1.45;
+}
+
+.inbox-thread-item.active .inbox-thread-phone,
+.inbox-thread-item.active .inbox-thread-preview,
+.inbox-thread-item.active .inbox-thread-time {
+  color: var(--inbox-thread-active-meta);
+}
+
+.inbox-thread-preview {
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.45rem;
 }
 
 .inbox-thread-time {
   color: var(--color-text-muted);
   font-size: var(--font-size-1);
+  margin-top: var(--space-1);
+}
+
+.inbox-thread-header-title {
+  color: var(--color-text);
+  font-size: var(--font-size-3);
+}
+
+.inbox-thread-header-meta,
+.inbox-thread-updated {
+  color: var(--color-text-muted);
+}
+
+.inbox-back-button {
+  width: 100%;
+  justify-content: center;
+}
+
+.inbox-mobile-actions {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-surface-muted);
+  padding: var(--space-2) var(--space-3);
+}
+
+.inbox-mobile-actions summary {
+  cursor: pointer;
+  color: var(--color-text);
+  font-weight: 600;
+  list-style: none;
+}
+
+.inbox-mobile-actions summary::-webkit-details-marker {
+  display: none;
+}
+
+.inbox-mobile-actions[open] summary {
+  margin-bottom: var(--space-2);
 }
 
 .inbox-message-pane {
   background: var(--color-surface-muted);
   max-height: 520px;
+}
+
+.inbox-message-row__inner {
+  gap: var(--space-2);
+  align-items: flex-start;
+  max-width: 92%;
+}
+
+.inbox-message-select {
+  flex: 0 0 auto;
+  margin-top: var(--space-2);
+}
+
+.inbox-message-bubble {
+  max-width: min(80%, 34rem);
+}
+
+.inbox-message-meta {
+  line-height: 1.45;
+}
+
+.inbox-delivery-error {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.inbox-delivery-error--on-primary {
+  color: var(--inbox-error-on-primary-text);
 }
 
 .inbox-reply-form {
@@ -723,6 +872,39 @@ h6,
   background: var(--color-surface);
   border-top: 1px solid var(--color-border);
   padding-top: var(--space-3);
+}
+
+.inbox-bulk-delete-btn:disabled,
+.inbox-bulk-delete-btn.disabled {
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+  background-color: transparent;
+  opacity: 1;
+}
+
+@media (max-width: 991.98px) {
+  .inbox-thread-header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .inbox-message-row__inner {
+    max-width: 100%;
+  }
+
+  .inbox-message-bubble {
+    max-width: calc(100% - 2.5rem);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .inbox-thread-item {
+    padding: var(--space-3);
+  }
+
+  .inbox-message-pane {
+    padding: var(--space-2) !important;
+  }
 }
 
 .preview-panel {

--- a/app/templates/inbox/list.html
+++ b/app/templates/inbox/list.html
@@ -21,8 +21,8 @@
 <div id="inboxStatusMeta" class="d-none"
      data-latest-message-id="{{ inbox_status_latest_message_id }}"
      data-status-url="{{ url_for('main.inbox_status') }}"></div>
-<div class="row g-3">
-    <div class="col-lg-4">
+<div class="row g-3 inbox-layout">
+    <div class="col-lg-4 {% if selected_thread %}d-none d-lg-block{% endif %}">
         <div class="card app-card mb-3">
             <div class="card-body">
                 <form method="GET" class="filter-bar">
@@ -38,60 +38,76 @@
         </div>
 
         <div class="card app-card inbox-threads-card">
-            <div class="list-group list-group-flush inbox-thread-list">
+            <div id="inboxThreadList" class="list-group list-group-flush inbox-thread-list" role="list" aria-label="Inbox threads">
                 {% if threads %}
                     {% for thread in threads %}
                     {% set thread_label = thread_display_names.get(thread.id, thread.contact_name or thread.phone) %}
                     {% set thread_is_active = selected_thread and thread.id == selected_thread.id %}
-                    <div class="list-group-item inbox-thread-item {% if thread_is_active %}active{% endif %}">
-                        <a class="text-decoration-none d-block {% if thread_is_active %}text-white{% else %}text-reset{% endif %}"
-                           href="{{ url_for('main.inbox_list', thread=thread.id, search=search) }}">
+                    <div class="list-group-item inbox-thread-item {% if thread_is_active %}active{% endif %}" role="listitem">
+                        <a class="text-decoration-none d-block inbox-thread-link"
+                           href="{{ url_for('main.inbox_list', thread=thread.id, search=search) }}"
+                           data-inbox-loading-trigger
+                           {% if thread_is_active %}aria-current="page"{% endif %}>
                             <div class="d-flex justify-content-between align-items-center gap-2">
                                 <div>
                                     <div class="fw-semibold">{{ thread_label }}</div>
                                     {% if thread_label != thread.phone %}
-                                    <div class="small {% if thread_is_active %}text-white-50{% else %}text-muted{% endif %}">{{ thread.phone }}</div>
+                                    <div class="small inbox-thread-phone">{{ thread.phone }}</div>
                                     {% endif %}
                                 </div>
                                 {% if thread.unread_count %}
                                 <span class="badge bg-danger rounded-pill">{{ thread.unread_count }}</span>
                                 {% endif %}
                             </div>
-                            <div class="small mt-1 inbox-thread-preview {% if thread_is_active %}text-white-50{% else %}text-muted{% endif %}">
+                            <div class="small mt-1 inbox-thread-preview">
                                 {{ thread.last_message_preview or 'No messages yet' }}
                             </div>
-                            <div class="small inbox-thread-time {% if thread_is_active %}text-white-50{% else %}text-muted{% endif %}">
+                            <div class="small inbox-thread-time">
                                 {{ thread.last_message_at|localtime('%b %d, %H:%M') }}
                             </div>
                         </a>
                     </div>
                     {% endfor %}
                 {% else %}
-                <div class="p-4 text-center text-muted">
-                    <i class="bi bi-chat-left-text fs-3 d-block mb-2"></i>
-                    No conversations yet.
+                <div class="empty-state">
+                    <i class="bi bi-chat-left-text empty-state__icon" aria-hidden="true"></i>
+                    <p class="empty-state__title">No conversations yet</p>
+                    <p class="empty-state__text">Inbound messages will appear here when contacts reply.</p>
                 </div>
                 {% endif %}
+            </div>
+            <div id="inboxThreadListSkeleton" class="inbox-thread-list-skeleton d-none p-3" aria-hidden="true">
+                <div class="inbox-skeleton-line inbox-skeleton-line--title"></div>
+                <div class="inbox-skeleton-line"></div>
+                <div class="inbox-skeleton-line"></div>
+                <div class="inbox-skeleton-line inbox-skeleton-line--title"></div>
+                <div class="inbox-skeleton-line"></div>
+                <div class="inbox-skeleton-line"></div>
             </div>
         </div>
     </div>
 
-    <div class="col-lg-8">
+    <div class="col-lg-8 {% if not selected_thread %}d-none d-lg-block{% endif %}">
         <div class="card app-card h-100">
             {% if selected_thread %}
             {% set selected_label = thread_display_names.get(selected_thread.id, selected_thread.contact_name or selected_thread.phone) %}
-            <div class="card-header d-flex justify-content-between align-items-center">
-                <div>
-                    <div class="fw-semibold">{{ selected_label }}</div>
+            <div class="d-lg-none px-3 pt-3">
+                <a class="btn btn-sm btn-outline-secondary inbox-back-button" href="{{ url_for('main.inbox_list', search=search) }}">
+                    <i class="bi bi-arrow-left me-1"></i>Back to threads
+                </a>
+            </div>
+            <div class="card-header inbox-thread-header d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2">
+                <div class="inbox-thread-header-text">
+                    <div class="fw-semibold inbox-thread-header-title">{{ selected_label }}</div>
                     {% if selected_label != selected_thread.phone %}
-                    <div class="small text-muted">{{ selected_thread.phone }}</div>
+                    <div class="small text-muted inbox-thread-header-meta">{{ selected_thread.phone }}</div>
                     {% endif %}
                 </div>
-                <div class="d-flex align-items-center gap-3">
-                    <div class="text-muted small">
+                <div class="d-flex flex-wrap align-items-center gap-2 gap-sm-3 inbox-thread-header-actions">
+                    <div class="text-muted small inbox-thread-updated">
                         Last updated {{ selected_thread.last_message_at|localtime('%b %d, %H:%M') }}
                     </div>
-                    <form method="POST" action="{{ url_for('main.inbox_thread_delete', thread_id=selected_thread.id) }}">
+                    <form method="POST" action="{{ url_for('main.inbox_thread_delete', thread_id=selected_thread.id) }}" class="d-none d-lg-block">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="search" value="{{ search }}">
                         <button class="btn btn-sm btn-outline-danger" type="submit"
@@ -100,6 +116,19 @@
                         </button>
                     </form>
                 </div>
+            </div>
+            <div class="px-3 pt-2 d-lg-none">
+                <details class="inbox-mobile-actions">
+                    <summary class="small">Thread actions</summary>
+                    <form method="POST" action="{{ url_for('main.inbox_thread_delete', thread_id=selected_thread.id) }}" class="mt-2 mb-0">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="search" value="{{ search }}">
+                        <button class="btn btn-sm btn-outline-danger w-100" type="submit"
+                                data-confirm="Delete this thread and all related messages/survey data?">
+                            <i class="bi bi-trash me-1"></i>Delete thread
+                        </button>
+                    </form>
+                </details>
             </div>
 
             <div class="card-body d-flex flex-column" style="min-height: 480px;">
@@ -132,13 +161,13 @@
                     <input type="hidden" name="search" value="{{ search }}">
                     <input type="hidden" name="thread_id" value="{{ selected_thread.id }}">
                 </form>
-                <div class="d-flex justify-content-between align-items-center mb-2">
+                <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2 mb-2">
                     <div class="form-check mb-0">
                         <input class="form-check-input" type="checkbox" id="selectAllMessages"
                                aria-label="Select all messages in thread">
                         <label class="form-check-label small" for="selectAllMessages">Select all messages</label>
                     </div>
-                    <button id="bulkMessageDeleteButton" class="btn btn-sm btn-outline-danger" type="submit"
+                    <button id="bulkMessageDeleteButton" class="btn btn-sm btn-outline-danger inbox-bulk-delete-btn" type="submit"
                             form="bulkMessageDeleteForm" data-confirm="Delete selected messages?"
                             aria-label="Delete selected messages" disabled>
                         <i class="bi bi-trash me-1"></i>Delete selected messages
@@ -148,14 +177,14 @@
                 <div id="inboxMessagePane" class="flex-grow-1 overflow-auto border rounded p-3 bg-light-subtle inbox-message-pane">
                     {% if messages %}
                         {% for message in messages %}
-                        <div class="d-flex mb-3 {% if message.direction == 'outbound' %}justify-content-end{% else %}justify-content-start{% endif %}">
-                            <div class="d-flex align-items-start gap-2 {% if message.direction == 'outbound' %}flex-row-reverse{% endif %}">
-                                <input class="form-check-input mt-2 js-message-select" type="checkbox" name="message_ids"
+                        <div class="d-flex mb-3 inbox-message-row {% if message.direction == 'outbound' %}justify-content-end{% else %}justify-content-start{% endif %}">
+                            <div class="d-flex align-items-start inbox-message-row__inner {% if message.direction == 'outbound' %}flex-row-reverse{% endif %}">
+                                <input class="form-check-input js-message-select inbox-message-select" type="checkbox" name="message_ids"
                                        value="{{ message.id }}" form="bulkMessageDeleteForm"
                                        aria-label="Select message {{ message.id }}">
-                                <div class="p-2 rounded {% if message.direction == 'outbound' %}bg-primary text-white{% else %}bg-white border{% endif %}" style="max-width: 80%;">
+                                <div class="p-2 rounded inbox-message-bubble {% if message.direction == 'outbound' %}bg-primary text-white{% else %}bg-white border{% endif %}">
                                     <div class="small mb-1">{{ message.body }}</div>
-                                    <div class="small {% if message.direction == 'outbound' %}text-white-50{% else %}text-muted{% endif %}">
+                                    <div class="small inbox-message-meta {% if message.direction == 'outbound' %}text-white-50{% else %}text-muted{% endif %}">
                                         {{ message.direction|capitalize }} • {{ message.created_at|localtime('%b %d, %H:%M') }}
                                         {% if message.matched_keyword %}
                                             • keyword: <code>{{ message.matched_keyword }}</code>
@@ -165,15 +194,29 @@
                                         {% endif %}
                                     </div>
                                     {% if message.delivery_error %}
-                                    <div class="small mt-1 text-warning-emphasis">{{ message.delivery_error }}</div>
+                                    <div class="small mt-1 inbox-delivery-error {% if message.direction == 'outbound' %}inbox-delivery-error--on-primary{% endif %}">
+                                        Delivery error: {{ message.delivery_error }}
+                                    </div>
                                     {% endif %}
                                 </div>
                             </div>
                         </div>
                         {% endfor %}
                     {% else %}
-                    <div class="text-center text-muted py-5">No messages yet for this thread.</div>
+                    <div class="empty-state py-4">
+                        <i class="bi bi-chat-square-text empty-state__icon" aria-hidden="true"></i>
+                        <p class="empty-state__title">No messages in this thread</p>
+                        <p class="empty-state__text">Messages and replies for this contact will appear here.</p>
+                    </div>
                     {% endif %}
+                </div>
+                <div id="inboxMessagePaneSkeleton" class="inbox-message-pane inbox-message-pane-skeleton border rounded p-3 bg-light-subtle d-none" aria-hidden="true">
+                    <div class="inbox-skeleton-line inbox-skeleton-line--title"></div>
+                    <div class="inbox-skeleton-line"></div>
+                    <div class="inbox-skeleton-line inbox-skeleton-line--short"></div>
+                    <div class="inbox-skeleton-line inbox-skeleton-line--title mt-3"></div>
+                    <div class="inbox-skeleton-line"></div>
+                    <div class="inbox-skeleton-line inbox-skeleton-line--short"></div>
                 </div>
 
                 <form method="POST" action="{{ url_for('main.inbox_reply', thread_id=selected_thread.id) }}" class="mt-3 inbox-reply-form">
@@ -189,9 +232,12 @@
                 </form>
             </div>
             {% else %}
-            <div class="card-body text-center text-muted py-5">
-                <i class="bi bi-chat-left-text fs-1 d-block mb-3"></i>
-                Select a thread to view messages.
+            <div class="card-body">
+                <div class="empty-state">
+                    <i class="bi bi-chat-left-text empty-state__icon" aria-hidden="true"></i>
+                    <p class="empty-state__title">Select a thread to view messages</p>
+                    <p class="empty-state__text">Choose a conversation from the inbox list to see details and send a reply.</p>
+                </div>
             </div>
             {% endif %}
         </div>
@@ -206,7 +252,32 @@
         pane.scrollTop = pane.scrollHeight;
     }
 
-    function bindSelectAll(selectAllId, itemSelector) {
+    const inboxLayout = document.querySelector('.inbox-layout');
+    const inboxThreadList = document.getElementById('inboxThreadList');
+    const inboxThreadListSkeleton = document.getElementById('inboxThreadListSkeleton');
+    const inboxMessagePane = document.getElementById('inboxMessagePane');
+    const inboxMessagePaneSkeleton = document.getElementById('inboxMessagePaneSkeleton');
+
+    const showInboxLoadingState = () => {
+        if (!inboxLayout) {
+            return;
+        }
+        inboxLayout.classList.add('inbox-layout-loading');
+        if (inboxThreadList && inboxThreadListSkeleton) {
+            inboxThreadList.classList.add('d-none');
+            inboxThreadListSkeleton.classList.remove('d-none');
+        }
+        if (inboxMessagePane && inboxMessagePaneSkeleton) {
+            inboxMessagePane.classList.add('d-none');
+            inboxMessagePaneSkeleton.classList.remove('d-none');
+        }
+    };
+
+    document.querySelectorAll('[data-inbox-loading-trigger]').forEach((trigger) => {
+        trigger.addEventListener('click', showInboxLoadingState);
+    });
+
+    function bindSelectAll(selectAllId, itemSelector, onSelectAllChange) {
         const selectAll = document.getElementById(selectAllId);
         if (!selectAll) {
             return [];
@@ -223,6 +294,9 @@
             items.forEach((item) => {
                 item.checked = selectAll.checked;
             });
+            if (onSelectAllChange) {
+                onSelectAllChange();
+            }
         });
 
         items.forEach((item) => {
@@ -234,17 +308,24 @@
         return items;
     }
 
-    const messageSelectionItems = bindSelectAll('selectAllMessages', '.js-message-select');
     const bulkMessageDeleteButton = document.getElementById('bulkMessageDeleteButton');
+    let messageSelectionItems = [];
     if (bulkMessageDeleteButton) {
         const syncBulkMessageDeleteState = () => {
             const hasSelection = messageSelectionItems.some((entry) => entry.checked);
             bulkMessageDeleteButton.disabled = !hasSelection;
         };
+        messageSelectionItems = bindSelectAll(
+            'selectAllMessages',
+            '.js-message-select',
+            syncBulkMessageDeleteState
+        );
         syncBulkMessageDeleteState();
         messageSelectionItems.forEach((entry) => {
             entry.addEventListener('change', syncBulkMessageDeleteState);
         });
+    } else {
+        messageSelectionItems = bindSelectAll('selectAllMessages', '.js-message-select');
     }
 
     const inboxStatusMeta = document.getElementById('inboxStatusMeta');


### PR DESCRIPTION
Summary
- implement the requested inbox UI/UX fixes: enhance thread selection contrast, add accessibility semantics, and tidy the desktop/mobile layouts per the audit plan
- introduce new CSS tokens for the selected state, clamp thread previews, and adjust header/bulk-action layouts
- align the mobile/desktop flows by hiding the thread list on narrow breakpoints and adding a mobile back control plus button grouping adjustments

Testing
- Not run (not requested)