### PR TITLE
Mitigate CSV formula injection in exports

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -68,6 +68,7 @@ from app.utils import (
     normalize_keyword,
     normalize_phone,
     parse_recipients_csv,
+    sanitize_csv_cell,
     validate_phone,
 )
 
@@ -565,7 +566,7 @@ def _stream_csv_rows(rows: object) -> object:
     for row in rows:
         output.seek(0)
         output.truncate(0)
-        writer.writerow(row)
+        writer.writerow([sanitize_csv_cell(cell) for cell in row])
         yield output.getvalue()
 
 
@@ -1170,7 +1171,11 @@ def community_export():
     writer = csv.writer(output)
     writer.writerow(['name', 'phone', 'created_at'])
     for member in members:
-        writer.writerow([member.name or '', member.phone, member.created_at.isoformat() if member.created_at else ''])
+        writer.writerow([
+            sanitize_csv_cell(member.name or ''),
+            sanitize_csv_cell(member.phone),
+            sanitize_csv_cell(member.created_at.isoformat() if member.created_at else ''),
+        ])
 
     response = make_response(output.getvalue())
     response.headers['Content-Type'] = 'text/csv'
@@ -1502,7 +1507,11 @@ def event_export_registrations(event_id):
     writer = csv.writer(output)
     writer.writerow(['name', 'phone', 'created_at'])
     for reg in registrations:
-        writer.writerow([reg.name or '', reg.phone, reg.created_at.isoformat() if reg.created_at else ''])
+        writer.writerow([
+            sanitize_csv_cell(reg.name or ''),
+            sanitize_csv_cell(reg.phone),
+            sanitize_csv_cell(reg.created_at.isoformat() if reg.created_at else ''),
+        ])
 
     response = make_response(output.getvalue())
     response.headers['Content-Type'] = 'text/csv'
@@ -2045,11 +2054,11 @@ def unsubscribed_export():
     writer.writerow(['name', 'phone', 'reason', 'source', 'created_at'])
     for entry in entries:
         writer.writerow([
-            entry.name or '',
-            entry.phone,
-            entry.reason or '',
-            entry.source,
-            entry.created_at.isoformat() if entry.created_at else '',
+            sanitize_csv_cell(entry.name or ''),
+            sanitize_csv_cell(entry.phone),
+            sanitize_csv_cell(entry.reason or ''),
+            sanitize_csv_cell(entry.source),
+            sanitize_csv_cell(entry.created_at.isoformat() if entry.created_at else ''),
         ])
 
     response = make_response(output.getvalue())

--- a/app/utils.py
+++ b/app/utils.py
@@ -10,6 +10,7 @@ _TEMPLATE_TOKEN_RE = re.compile(
     re.IGNORECASE,
 )
 _TEMPLATE_TOKEN_SCAN_RE = re.compile(r"\{([^{}]+)\}")
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@")
 
 
 def escape_like(value: str) -> str:
@@ -103,6 +104,25 @@ def find_invalid_template_tokens(template: str) -> list[str]:
                 invalid_tokens.append(raw)
                 seen.add(raw)
     return invalid_tokens
+
+
+def sanitize_csv_cell(value: object) -> str:
+    """
+    Prevent CSV/formula injection when opening exports in spreadsheet clients.
+
+    Any cell beginning with characters interpreted as formulas is prefixed with
+    a single quote so it is treated as literal text.
+    """
+    if value is None:
+        return ""
+
+    text = str(value)
+    if not text:
+        return text
+
+    if text[0] in _CSV_FORMULA_PREFIXES or text[0] in ("\t", "\r", "\n"):
+        return f"'{text}"
+    return text
 
 
 def _looks_like_phone(value: str) -> bool:

--- a/tests/test_export_csv_security.py
+++ b/tests/test_export_csv_security.py
@@ -1,0 +1,120 @@
+import csv
+import importlib
+import io
+import os
+import tempfile
+import unittest
+
+
+class TestCsvExportSecurity(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, CommunityMember, Event, EventRegistration, UnsubscribedContact
+
+        self.db = db
+        self.AppUser = AppUser
+        self.CommunityMember = CommunityMember
+        self.Event = Event
+        self.EventRegistration = EventRegistration
+        self.UnsubscribedContact = UnsubscribedContact
+
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin.set_password("admin-pass")
+        self.db.session.add(admin)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self) -> None:
+        response = self.client.post(
+            "/login",
+            data={"username": "admin", "password": "admin-pass"},
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_community_export_escapes_formula_cells(self) -> None:
+        self._login()
+        member = self.CommunityMember(name="=2+2", phone="+17205550101")
+        self.db.session.add(member)
+        self.db.session.commit()
+
+        response = self.client.get("/community/export")
+        self.assertEqual(response.status_code, 200)
+
+        rows = list(csv.DictReader(io.StringIO(response.get_data(as_text=True))))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "'=2+2")
+        self.assertEqual(rows[0]["phone"], "'+17205550101")
+
+    def test_event_export_escapes_formula_cells(self) -> None:
+        self._login()
+        event = self.Event(title="Safe Export Event")
+        self.db.session.add(event)
+        self.db.session.flush()
+        reg = self.EventRegistration(event_id=event.id, name="@evil", phone="+17205550102")
+        self.db.session.add(reg)
+        self.db.session.commit()
+
+        response = self.client.get(f"/events/{event.id}/export")
+        self.assertEqual(response.status_code, 200)
+
+        rows = list(csv.DictReader(io.StringIO(response.get_data(as_text=True))))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "'@evil")
+        self.assertEqual(rows[0]["phone"], "'+17205550102")
+
+    def test_unsubscribed_export_escapes_formula_cells(self) -> None:
+        self._login()
+        entry = self.UnsubscribedContact(
+            name="-name",
+            phone="+17205550103",
+            reason="=SUM(1,1)",
+            source="@manual",
+        )
+        self.db.session.add(entry)
+        self.db.session.commit()
+
+        response = self.client.get("/unsubscribed/export")
+        self.assertEqual(response.status_code, 200)
+
+        rows = list(csv.DictReader(io.StringIO(response.get_data(as_text=True))))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "'-name")
+        self.assertEqual(rows[0]["phone"], "'+17205550103")
+        self.assertEqual(rows[0]["reason"], "'=SUM(1,1)")
+        self.assertEqual(rows[0]["source"], "'@manual")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `sanitize_csv_cell` to neutralize formula-like values in CSV exports
- apply sanitization to survey stream exports and all direct CSV export routes
- add regression tests for utility behavior and export endpoints

## Security impact
Prevents spreadsheet formula execution when admins/social managers open exported CSV files in Excel.

## Validation
- conda run -n sms-admin python -m unittest tests.test_utils tests.test_inbox_routes.TestInboxRoutes.test_survey_submissions_export_includes_all_completed_and_latest_flag tests.test_inbox_routes.TestInboxRoutes.test_survey_submissions_export_escapes_formula_injection_cells tests.test_export_csv_security