### PR TITLE
Expose Delete action on mobile events list and add tests

### DIFF
--- a/app/templates/events/list.html
+++ b/app/templates/events/list.html
@@ -180,7 +180,18 @@
                     <a href="{{ url_for('main.event_edit', event_id=event.id) }}" class="btn btn-sm btn-outline-secondary">
                         <i class="bi bi-pencil"></i> Edit
                     </a>
+                    <button type="button" class="btn btn-sm btn-outline-danger"
+                            data-bs-toggle="modal" data-bs-target="#deleteEventModal"
+                            data-form-id="delete-event-mobile-{{ event.id }}"
+                            data-event-title="{{ event.title }}"
+                            data-registration-count="{{ event.registrations|length }}">
+                        <i class="bi bi-trash"></i> Delete
+                    </button>
                 </div>
+                <form method="POST" action="{{ url_for('main.event_delete', event_id=event.id) }}"
+                      id="delete-event-mobile-{{ event.id }}" style="display:none;">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                </form>
             </div>
             {% endfor %}
         {% else %}

--- a/tests/test_events_routes.py
+++ b/tests/test_events_routes.py
@@ -1,0 +1,104 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestEventsRoutes(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, Event, SurveyFlow
+
+        self.db = db
+        self.AppUser = AppUser
+        self.Event = Event
+        self.SurveyFlow = SurveyFlow
+
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin.set_password("admin-pass")
+        self.db.session.add(admin)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self) -> None:
+        response = self.client.post(
+            "/login",
+            data={"username": "admin", "password": "admin-pass"},
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_events_list_mobile_cards_include_delete_action(self) -> None:
+        self._login()
+
+        event = self.Event(title="Community Picnic")
+        self.db.session.add(event)
+        self.db.session.commit()
+
+        response = self.client.get("/events")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"delete-event-mobile-{event.id}".encode(), response.data)
+        self.assertIn(b'bi bi-trash"></i> Delete', response.data)
+
+    def test_events_list_mobile_delete_action_present_for_survey_linked_event(self) -> None:
+        self._login()
+
+        event = self.Event(title="AOC Gala")
+        self.db.session.add(event)
+        self.db.session.flush()
+
+        survey = self.SurveyFlow(
+            name="RSVP Flow",
+            trigger_keyword="AOC RSVP",
+            intro_message="Welcome!",
+            completion_message="Thanks!",
+            linked_event_id=event.id,
+            is_active=True,
+        )
+        survey.set_questions(["Name?"])
+        self.db.session.add(survey)
+        self.db.session.commit()
+
+        response = self.client.get("/events")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'data-event-title="{event.title}"'.encode(), response.data)
+        self.assertIn(f"delete-event-mobile-{event.id}".encode(), response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Mobile event cards did not include a Delete action, which made events (including those created via survey flows) appear undeletable on small screens. 

### Description
- Add a mobile delete button to the event card layout in `app/templates/events/list.html` that opens the existing `#deleteEventModal` and targets a hidden POST form. 
- Add a hidden form per mobile card wired to the existing `main.event_delete` route and `csrf_token()` so deletion reuses the current backend flow. 
- Add `tests/test_events_routes.py` with two focused tests that assert the mobile list includes the delete action for both regular events and survey-linked events. 
- No backend route or delete logic was changed; this is a UI/templating fix with regression coverage. 

### Testing
- Ran `pytest -q tests/test_events_routes.py` and the new tests passed (`2 passed`).
- Ran `pytest -q tests/test_export_csv_security.py` and those tests passed (`3 passed`).
- Ran the full test suite with `pytest -q`, which produced two pre-existing failures in unrelated inbox automation tests; those failures are not caused by this UI change (result: `2 failed, 126 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0feb50d88324ad8dd09af658596d)