### PR TITLE
Hide stale inbox keywords behind reveal control

### DIFF
--- a/app/templates/inbox/list.html
+++ b/app/templates/inbox/list.html
@@ -187,7 +187,18 @@
                                     <div class="small inbox-message-meta {% if message.direction == 'outbound' %}text-white-50{% else %}text-muted{% endif %}">
                                         {{ message.direction|capitalize }} • {{ message.created_at|localtime('%b %d, %H:%M') }}
                                         {% if message.matched_keyword %}
-                                            • keyword: <code>{{ message.matched_keyword }}</code>
+                                            {% if message.matched_keyword in active_trigger_keywords %}
+                                                • keyword: <code>{{ message.matched_keyword }}</code>
+                                            {% else %}
+                                                • keyword hidden
+                                                <span class="badge rounded-pill text-bg-secondary">inactive</span>
+                                                <details class="mt-1">
+                                                    <summary class="small">Show historical keyword</summary>
+                                                    <div class="small">
+                                                        Historical keyword: <code>{{ message.matched_keyword }}</code>
+                                                    </div>
+                                                </details>
+                                            {% endif %}
                                         {% endif %}
                                         {% if message.direction == 'outbound' and message.delivery_status %}
                                             • {{ message.delivery_status }}


### PR DESCRIPTION
## Summary
- hide keywords on inbox messages once the referenced keyword is deleted so stale labels no longer confuse users
- surface an inline indicator and reveal control so each hidden keyword can be retrieved as needed
- allow reclaimed keyword names to be reused without displaying misleading old labels

## Testing
- Not run (not requested)