### PR TITLE
Enforce Python 3.11 runtime in deploy and CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,12 @@ jobs:
           sudo systemctl is-active --quiet sms-scheduler.timer
 
           echo "==> Dependency assertions"
+          PYTHON_VERSION="$(sudo -u smsadmin /opt/sms-admin/venv/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+          if [ "$PYTHON_VERSION" != "3.11" ]; then
+            echo "❌ python version mismatch: expected 3.11, got $PYTHON_VERSION"
+            exit 1
+          fi
+
           CLICK_VERSION="$(sudo -u smsadmin /opt/sms-admin/venv/bin/python -c "from importlib.metadata import version; print(version('click'))")"
           if [ "$CLICK_VERSION" != "8.1.7" ]; then
             echo "❌ click version mismatch: expected 8.1.7, got $CLICK_VERSION"

--- a/.github/workflows/tests-python311.yml
+++ b/.github/workflows/tests-python311.yml
@@ -1,0 +1,28 @@
+name: Tests (Python 3.11)
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Optional helper (Codex-friendly; preserves existing `.env`):
 
 The helper script creates/uses the local `venv`, installs Python dependencies, and only copies
 `.env.example` to `.env` if `.env` does not already exist.
+It fails fast if your interpreter or existing `venv` is not Python 3.11.
 
 ### 2. Configure Environment
 
@@ -129,7 +130,7 @@ Required environment variables:
 - `TWILIO_ACCOUNT_SID` - Your Twilio Account SID
 - `TWILIO_AUTH_TOKEN` - Your Twilio Auth Token
 - `TWILIO_FROM_NUMBER` - Your Twilio phone number (E.164 format, e.g., +1234567890)
-- `SECRET_KEY` - Flask secret key (generate with `python -c "import secrets; print(secrets.token_hex(32))"`)
+- `SECRET_KEY` - Flask secret key (generate with `python3.11 -c "import secrets; print(secrets.token_hex(32))"`)
 
 ### 3. Run Development Server
 

--- a/deploy/check_python_runtime.sh
+++ b/deploy/check_python_runtime.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="${APP_ROOT:-/opt/sms-admin}"
+PYTHON_BIN="${PYTHON_BIN:-${APP_ROOT}/venv/bin/python}"
+REQUIRED_PYTHON="${REQUIRED_PYTHON:-3.11}"
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "[python-runtime] ERROR: Python executable not found at ${PYTHON_BIN}" >&2
+  exit 1
+fi
+
+DETECTED_PYTHON="$("${PYTHON_BIN}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+if [[ "${DETECTED_PYTHON}" != "${REQUIRED_PYTHON}" ]]; then
+  echo "[python-runtime] ERROR: ${PYTHON_BIN} is Python ${DETECTED_PYTHON}; expected ${REQUIRED_PYTHON}." >&2
+  echo "[python-runtime] Recreate /opt/sms-admin/venv with python3.11 before starting services." >&2
+  exit 1
+fi

--- a/deploy/run_scheduler_once.sh
+++ b/deploy/run_scheduler_once.sh
@@ -5,16 +5,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="${APP_ROOT:-/opt/sms-admin}"
 VENV_PYTHON="${APP_ROOT}/venv/bin/python"
 ENV_FILE="${APP_ROOT}/.env"
 
-# Verify venv exists
-if [[ ! -x "${VENV_PYTHON}" ]]; then
-    echo "[sms-scheduler] ERROR: Python not found at ${VENV_PYTHON}" >&2
-    exit 1
-fi
+"${APP_ROOT}/deploy/check_python_runtime.sh"
 
 # Load environment file if it exists
 if [[ -f "${ENV_FILE}" ]]; then

--- a/deploy/run_worker.sh
+++ b/deploy/run_worker.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 PATH=/usr/bin:/bin:/opt/sms-admin/venv/bin
 
+/opt/sms-admin/deploy/check_python_runtime.sh
+
 if [ -f /opt/sms-admin/.env ]; then
   set -a
   . /opt/sms-admin/.env

--- a/deploy/sms-scheduler.service
+++ b/deploy/sms-scheduler.service
@@ -9,6 +9,7 @@ Group=smsadmin
 WorkingDirectory=/opt/sms-admin
 Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 EnvironmentFile=-/opt/sms-admin/.env
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
 ExecStart=/bin/bash /opt/sms-admin/deploy/run_scheduler_once.sh
 
 # Logging - all output goes to journal

--- a/deploy/sms-worker.service
+++ b/deploy/sms-worker.service
@@ -9,6 +9,7 @@ WorkingDirectory=/opt/sms-admin
 Environment="SCHEDULER_ENABLED=0"
 Environment="RQ_QUEUE_NAME=sms"
 EnvironmentFile=/opt/sms-admin/.env
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
 ExecStartPre=/opt/sms-admin/venv/bin/python -m app.dbdoctor --apply
 ExecStart=/bin/bash /opt/sms-admin/deploy/run_worker.sh
 Restart=on-failure

--- a/deploy/sms.service
+++ b/deploy/sms.service
@@ -9,6 +9,7 @@ WorkingDirectory=/opt/sms-admin
 Environment="PATH=/opt/sms-admin/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="SCHEDULER_ENABLED=0"
 EnvironmentFile=/opt/sms-admin/.env
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
 ExecStartPre=/usr/local/bin/dbdoctor --apply
 ExecStart=/opt/sms-admin/venv/bin/gunicorn --workers 1 --bind 127.0.0.1:8000 --access-logfile /var/log/sms-admin/access.log --error-logfile /var/log/sms-admin/error.log wsgi:app
 ExecReload=/bin/kill -s HUP $MAINPID

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,6 +59,7 @@ sudo chown -R smsadmin:smsadmin /opt/sms-admin
 ```bash
 sudo -u smsadmin bash -c 'cd /opt/sms-admin && python3.11 -m venv venv'
 sudo -u smsadmin bash -c 'cd /opt/sms-admin && source venv/bin/activate && pip install -r requirements.txt'
+sudo -u smsadmin /opt/sms-admin/venv/bin/python -c "import sys; print(f'Python {sys.version_info.major}.{sys.version_info.minor}')"
 ```
 
 ### 5. Configure Environment
@@ -161,6 +162,7 @@ User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
 EnvironmentFile=/opt/sms-admin/.env
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
 ExecStartPre=/usr/local/bin/dbdoctor --apply
 ExecStart=/opt/sms-admin/venv/bin/gunicorn \
     --workers 2 \
@@ -188,6 +190,7 @@ User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
 EnvironmentFile=/opt/sms-admin/.env
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
 ExecStart=/opt/sms-admin/venv/bin/rq worker sms
 Restart=always
 
@@ -227,7 +230,8 @@ User=smsadmin
 Group=smsadmin
 WorkingDirectory=/opt/sms-admin
 EnvironmentFile=/opt/sms-admin/.env
-ExecStart=/opt/sms-admin/deploy/run_scheduler_once.sh
+ExecStartPre=/opt/sms-admin/deploy/check_python_runtime.sh
+ExecStart=/bin/bash /opt/sms-admin/deploy/run_scheduler_once.sh
 ```
 
 ## Verification

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -197,6 +197,24 @@ sudo systemctl restart sms
 
 ## Service Issues
 
+### "expected 3.11" / "python version mismatch"
+
+**Cause:** The app venv was created with the wrong Python version.
+
+**Check:**
+```bash
+/opt/sms-admin/venv/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+```
+
+**Fix:**
+```bash
+sudo systemctl stop sms sms-worker sms-scheduler.timer
+sudo rm -rf /opt/sms-admin/venv
+sudo -u smsadmin bash -c 'cd /opt/sms-admin && python3.11 -m venv venv'
+sudo -u smsadmin bash -c 'cd /opt/sms-admin && source venv/bin/activate && pip install -r requirements.txt'
+sudo systemctl start sms sms-worker sms-scheduler.timer
+```
+
 ### sms.service Won't Start
 
 **Check logs:**


### PR DESCRIPTION
## Summary
- add runtime guard to enforce Python 3.11 in deployed services and wrappers
- fail deploy/install early when venv is not Python 3.11, and auto-create venv with python3.11 when missing
- add Python 3.11 CI test workflow and deploy-time Python version assertion
- update docs/troubleshooting with Python 3.11 verification and recovery steps

## Validation
- bash -n deploy/check_python_runtime.sh
- bash -n deploy/install.sh
- bash -n deploy/run_worker.sh
- bash -n deploy/run_scheduler_once.sh
- pytest -q tests/test_bulk_selection_ui_consistency.py