### PR TITLE
Harden production security config, login controls, and bootstrap secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ FLASK_ENV=production
 # FLASK_DEBUG=1
 
 # Optional: trust reverse proxy forwarded headers when behind a known proxy
-# TRUST_PROXY=0
+# Recommended in production behind nginx: 1
+# TRUST_PROXY=1
 
 # Admin Credentials (required for login and clearing logs)
 ADMIN_USERNAME=admin
@@ -50,3 +51,25 @@ SCHEDULER_ENABLED=0
 # Optional: cookie settings (prod defaults are secure)
 # SESSION_COOKIE_SAMESITE=Lax
 # SESSION_COOKIE_SECURE=1
+
+# Security hardening for login + sessions (recommended production values)
+# Number of seconds to count failed login attempts (recommended: 300 = 5 minutes)
+# AUTH_ATTEMPT_WINDOW_SECONDS=300
+# Number of seconds an account/IP is locked after too many failures (recommended: 900 = 15 minutes)
+# AUTH_LOCKOUT_SECONDS=900
+# Max failures allowed for one username coming from one IP (recommended: 5)
+# AUTH_MAX_ATTEMPTS_IP_ACCOUNT=5
+# Max failures allowed for one username across all IPs (recommended: 8)
+# AUTH_MAX_ATTEMPTS_ACCOUNT=8
+# Max failures allowed from one IP across all usernames (recommended: 30)
+# AUTH_MAX_ATTEMPTS_IP=30
+# Idle session timeout in minutes (recommended: 30)
+# SESSION_IDLE_TIMEOUT_MINUTES=30
+# Remember-me cookie duration in days (recommended: 7)
+# REMEMBER_COOKIE_DURATION_DAYS=7
+# Minimum password length for UI password changes/creation (recommended: 12)
+# AUTH_PASSWORD_MIN_LENGTH=12
+# Enforce password policy checks in UI forms (recommended in production: 1)
+# AUTH_PASSWORD_POLICY_ENFORCE=1
+# Comma-separated hostnames allowed in production requests (recommended: your real domain)
+# TRUSTED_HOSTS=sms.theitwingman.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,11 @@ jobs:
             "$VPS_USER@$VPS_HOST" 'bash -s' <<'REMOTE'
           set -euo pipefail
 
-          echo "==> Deploy: pull + deps + restart"
+          echo "==> Bootstrap deploy script from repo"
+          sudo -u smsadmin bash -c 'cd /opt/sms-admin && git pull --ff-only'
+          sudo install -m 0755 /opt/sms-admin/deploy/deploy_sms_admin.sh /usr/local/bin/deploy_sms_admin.sh
+
+          echo "==> Deploy: pull + deps + restart + hardening env sync"
           sudo /usr/local/bin/deploy_sms_admin.sh
 
           echo "==> Service status"
@@ -96,6 +100,24 @@ jobs:
 
           echo "==> Health check (Gunicorn direct)"
           curl -fsS http://127.0.0.1:8000/health >/dev/null
+
+          echo "==> Security hardening env key assertions"
+          for key in \
+            AUTH_ATTEMPT_WINDOW_SECONDS \
+            AUTH_LOCKOUT_SECONDS \
+            AUTH_MAX_ATTEMPTS_IP_ACCOUNT \
+            AUTH_MAX_ATTEMPTS_ACCOUNT \
+            AUTH_MAX_ATTEMPTS_IP \
+            SESSION_IDLE_TIMEOUT_MINUTES \
+            REMEMBER_COOKIE_DURATION_DAYS \
+            AUTH_PASSWORD_MIN_LENGTH \
+            AUTH_PASSWORD_POLICY_ENFORCE \
+            TRUSTED_HOSTS; do
+            grep -q "^${key}=" /opt/sms-admin/.env || {
+              echo "❌ missing ${key} in /opt/sms-admin/.env"
+              exit 1
+            }
+          done
 
           echo "✅ Deploy complete and healthy"
           REMOTE

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Optional helper (Codex-friendly; preserves existing `.env`):
 The helper script creates/uses the local `venv`, installs Python dependencies, and only copies
 `.env.example` to `.env` if `.env` does not already exist.
 It fails fast if your interpreter or existing `venv` is not Python 3.11.
+It also installs `pytest` and `pytest-cov` so local test runs work out of the box.
 
 ### 2. Configure Environment
 
@@ -453,14 +454,14 @@ Phone formats accepted: `+1234567890`, `(323) 630-0201`, `720-383-2388`, `323630
 ## Testing
 
 ```bash
-# Run all tests
-pytest
+# Run this repo's tests with automatic venv/dependency checks
+./run/test.sh
 
 # Run with coverage
-pytest --cov=app
+./run/test.sh --cov=app
 
 # Run specific test file
-pytest tests/test_utils.py
+./run/test.sh tests/test_utils.py
 ```
 
 ## Assumptions

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, request
+from flask import Flask, request, abort
 from flask_sqlalchemy import SQLAlchemy
 from pathlib import Path
 from typing import Optional
@@ -12,6 +12,61 @@ from werkzeug.security import generate_password_hash
 
 db = SQLAlchemy()
 csrf = CSRFProtect()
+
+
+def _validate_production_security_config(app: Flask) -> None:
+    errors: list[str] = []
+
+    def expect_int_range(name: str, minimum: int, maximum: int) -> None:
+        value = app.config.get(name)
+        if not isinstance(value, int):
+            errors.append(f"{name} must be an integer.")
+            return
+        if value < minimum or value > maximum:
+            errors.append(f"{name} must be between {minimum} and {maximum}. Current value: {value}.")
+
+    if app.config.get("SESSION_COOKIE_SECURE") is not True:
+        errors.append("SESSION_COOKIE_SECURE must be enabled (1) in production.")
+    if app.config.get("REMEMBER_COOKIE_SECURE") is not True:
+        errors.append("REMEMBER_COOKIE_SECURE must be enabled (1) in production.")
+    if app.config.get("SESSION_COOKIE_HTTPONLY") is not True:
+        errors.append("SESSION_COOKIE_HTTPONLY must remain enabled.")
+    if app.config.get("REMEMBER_COOKIE_HTTPONLY") is not True:
+        errors.append("REMEMBER_COOKIE_HTTPONLY must remain enabled.")
+    if app.config.get("SESSION_COOKIE_SAMESITE") not in {"Lax", "Strict"}:
+        errors.append("SESSION_COOKIE_SAMESITE must be Lax or Strict in production.")
+
+    expect_int_range("AUTH_ATTEMPT_WINDOW_SECONDS", 60, 86400)
+    expect_int_range("AUTH_LOCKOUT_SECONDS", 60, 86400)
+    expect_int_range("AUTH_MAX_ATTEMPTS_IP_ACCOUNT", 1, 100)
+    expect_int_range("AUTH_MAX_ATTEMPTS_ACCOUNT", 1, 200)
+    expect_int_range("AUTH_MAX_ATTEMPTS_IP", 1, 500)
+    expect_int_range("SESSION_IDLE_TIMEOUT_MINUTES", 5, 1440)
+    expect_int_range("REMEMBER_COOKIE_DURATION_DAYS", 1, 30)
+    expect_int_range("AUTH_PASSWORD_MIN_LENGTH", 12, 128)
+
+    if app.config.get("AUTH_PASSWORD_POLICY_ENFORCE") is not True:
+        errors.append("AUTH_PASSWORD_POLICY_ENFORCE must be enabled (1) in production.")
+
+    ip_account_limit = app.config.get("AUTH_MAX_ATTEMPTS_IP_ACCOUNT")
+    account_limit = app.config.get("AUTH_MAX_ATTEMPTS_ACCOUNT")
+    ip_limit = app.config.get("AUTH_MAX_ATTEMPTS_IP")
+    if isinstance(ip_account_limit, int) and isinstance(account_limit, int):
+        if ip_account_limit > account_limit:
+            errors.append(
+                "AUTH_MAX_ATTEMPTS_IP_ACCOUNT should not be greater than AUTH_MAX_ATTEMPTS_ACCOUNT."
+            )
+    if isinstance(account_limit, int) and isinstance(ip_limit, int):
+        if account_limit > ip_limit:
+            errors.append("AUTH_MAX_ATTEMPTS_ACCOUNT should not be greater than AUTH_MAX_ATTEMPTS_IP.")
+
+    trusted_hosts = app.config.get("TRUSTED_HOSTS") or []
+    if not trusted_hosts:
+        errors.append("TRUSTED_HOSTS must include your production hostnames.")
+
+    if errors:
+        details = "\n - ".join(errors)
+        raise RuntimeError(f"Production security configuration is invalid:\n - {details}")
 
 
 def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] = None):
@@ -50,9 +105,24 @@ def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] =
 
     app.config.from_object(Config)
 
+    is_explicit_production = os.environ.get("FLASK_ENV", "").lower() == "production"
     if not app.config.get("DEBUG"):
         if app.config.get("SECRET_KEY") == "dev-secret-key-change-in-production":
             raise RuntimeError("SECRET_KEY must be set in production")
+        if is_explicit_production:
+            _validate_production_security_config(app)
+
+    if is_explicit_production and app.config.get("TRUSTED_HOSTS"):
+        trusted_hosts = {host.strip().lower() for host in app.config.get("TRUSTED_HOSTS", []) if host.strip()}
+
+        @app.before_request
+        def enforce_trusted_hosts():
+            host = (request.host or "").split(":", 1)[0].strip().lower()
+            if host in {"127.0.0.1", "localhost"}:
+                return None
+            if host not in trusted_hosts:
+                abort(400)
+            return None
 
     if app.config.get("TRUST_PROXY"):
         app.wsgi_app = ProxyFix(

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin, urlparse
 from functools import wraps
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, current_app
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
 from app import db
 from app.models import AppUser, LoginAttempt
@@ -13,13 +13,42 @@ login_manager.login_message_category = 'warning'
 
 bp = Blueprint('auth', __name__)
 
-_MAX_LOGIN_ATTEMPTS = 5
-_ATTEMPT_WINDOW_SECONDS = 300
-_LOCKOUT_SECONDS = 600
-
 
 def _get_client_ip():
     return request.remote_addr or 'unknown'
+
+
+def _normalize_username(username: str | None) -> str:
+    return (username or '').strip().lower()
+
+
+def _attempt_window_seconds() -> int:
+    return int(current_app.config.get('AUTH_ATTEMPT_WINDOW_SECONDS', 300))
+
+
+def _lockout_seconds() -> int:
+    return int(current_app.config.get('AUTH_LOCKOUT_SECONDS', 900))
+
+
+def _keys_for_login_attempt(username: str | None, include_legacy_ip: bool = False) -> list[str]:
+    client_ip = _get_client_ip()
+    normalized_username = _normalize_username(username)
+
+    keys = [f'ip:{client_ip}']
+    if include_legacy_ip:
+        keys.append(client_ip)
+    if normalized_username:
+        keys.append(f'account:{normalized_username}')
+        keys.append(f'ip_account:{client_ip}:{normalized_username}')
+    return keys
+
+
+def _attempt_limit_for_key(key: str) -> int:
+    if key.startswith('ip_account:'):
+        return int(current_app.config.get('AUTH_MAX_ATTEMPTS_IP_ACCOUNT', 5))
+    if key.startswith('account:'):
+        return int(current_app.config.get('AUTH_MAX_ATTEMPTS_ACCOUNT', 8))
+    return int(current_app.config.get('AUTH_MAX_ATTEMPTS_IP', 30))
 
 
 def _is_safe_url(target):
@@ -30,62 +59,78 @@ def _is_safe_url(target):
     return redirect_url.scheme in ('http', 'https') and host_url.netloc == redirect_url.netloc
 
 
-def _login_rate_limited():
-    client_ip = _get_client_ip()
+def _login_rate_limited(username: str | None):
     now = datetime.now(timezone.utc)
+    lockout_seconds = _lockout_seconds()
+    attempt_window_seconds = _attempt_window_seconds()
 
-    record = LoginAttempt.query.filter_by(client_ip=client_ip).first()
-    if not record:
-        return False, None
+    keys = _keys_for_login_attempt(username, include_legacy_ip=True)
+    records = LoginAttempt.query.filter(LoginAttempt.client_ip.in_(keys)).all()
 
-    if record.locked_until:
-        if now < record.locked_until.replace(tzinfo=timezone.utc):
-            remaining = (record.locked_until.replace(tzinfo=timezone.utc) - now).total_seconds()
-            return True, remaining
-        else:
-            db.session.delete(record)
-            db.session.commit()
-            return False, None
+    records_to_delete = []
+    record_changed = False
+    max_remaining = 0.0
 
-    first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
-    if (now - first_attempt).total_seconds() > _ATTEMPT_WINDOW_SECONDS:
+    for record in records:
+        if record.locked_until:
+            locked_until = record.locked_until.replace(tzinfo=timezone.utc)
+            if now < locked_until:
+                remaining = (locked_until - now).total_seconds()
+                max_remaining = max(max_remaining, remaining)
+                continue
+
+            records_to_delete.append(record)
+            continue
+
+        first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
+        if (now - first_attempt).total_seconds() > attempt_window_seconds:
+            records_to_delete.append(record)
+            continue
+
+        max_attempts = _attempt_limit_for_key(record.client_ip)
+        if record.attempt_count >= max_attempts:
+            record.locked_until = now + timedelta(seconds=lockout_seconds)
+            record_changed = True
+            max_remaining = max(max_remaining, float(lockout_seconds))
+
+    for record in records_to_delete:
         db.session.delete(record)
-        db.session.commit()
-        return False, None
+        record_changed = True
 
-    if record.attempt_count >= _MAX_LOGIN_ATTEMPTS:
-        record.locked_until = now + timedelta(seconds=_LOCKOUT_SECONDS)
+    if record_changed:
         db.session.commit()
-        return True, _LOCKOUT_SECONDS
+
+    if max_remaining > 0:
+        return True, max_remaining
 
     return False, None
 
 
-def _record_failed_login():
-    client_ip = _get_client_ip()
+def _record_failed_login(username: str | None):
     now = datetime.now(timezone.utc)
+    attempt_window_seconds = _attempt_window_seconds()
 
-    record = LoginAttempt.query.filter_by(client_ip=client_ip).first()
-    if not record:
-        record = LoginAttempt(client_ip=client_ip, attempt_count=1, first_attempt_at=now)
-        db.session.add(record)
-        db.session.commit()
-        return
+    for key in _keys_for_login_attempt(username):
+        record = LoginAttempt.query.filter_by(client_ip=key).first()
+        if not record:
+            record = LoginAttempt(client_ip=key, attempt_count=1, first_attempt_at=now)
+            db.session.add(record)
+            continue
 
-    first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
-    if (now - first_attempt).total_seconds() > _ATTEMPT_WINDOW_SECONDS:
-        record.attempt_count = 1
-        record.first_attempt_at = now
-        record.locked_until = None
-    else:
-        record.attempt_count += 1
+        first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
+        if (now - first_attempt).total_seconds() > attempt_window_seconds:
+            record.attempt_count = 1
+            record.first_attempt_at = now
+            record.locked_until = None
+        else:
+            record.attempt_count += 1
 
     db.session.commit()
 
 
-def _clear_failed_logins():
-    client_ip = _get_client_ip()
-    LoginAttempt.query.filter_by(client_ip=client_ip).delete()
+def _clear_failed_logins(username: str | None):
+    keys = _keys_for_login_attempt(username, include_legacy_ip=True)
+    LoginAttempt.query.filter(LoginAttempt.client_ip.in_(keys)).delete(synchronize_session=False)
     db.session.commit()
 
 
@@ -131,29 +176,29 @@ def load_user(user_id):
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
-        limited, remaining = _login_rate_limited()
+        username = request.form.get('username', '').strip()
+        password = request.form.get('password', '')
+        remember = request.form.get('remember') == 'on'
+
+        limited, remaining = _login_rate_limited(username)
         if limited:
             minutes = max(1, int(remaining // 60))
             flash(f'Too many failed attempts. Try again in {minutes} minute(s).', 'error')
             return render_template('auth/login.html')
 
-        username = request.form.get('username', '').strip()
-        password = request.form.get('password', '')
-        remember = request.form.get('remember') == 'on'
-        
         user = AppUser.query.filter_by(username=username).first()
-        
+
         if user and user.check_password(password):
             login_user(user, remember=remember)
-            _clear_failed_logins()
+            _clear_failed_logins(username)
             if user.must_change_password:
                 return redirect(url_for('main.change_password'))
             next_page = request.args.get('next')
             if next_page and _is_safe_url(next_page):
                 return redirect(next_page)
             return redirect(url_for('main.dashboard'))
-        
-        _record_failed_login()
+
+        _record_failed_login(username)
         flash('Invalid username or password.', 'error')
     
     return render_template('auth/login.html')

--- a/app/config.py
+++ b/app/config.py
@@ -1,26 +1,100 @@
 import os
+from datetime import timedelta
 from pathlib import Path
+
+
+def _env_bool(name: str, default: str) -> bool:
+    return os.environ.get(name, default) == '1'
+
+
+def _env_int(name: str, default: str) -> int:
+    raw_value = os.environ.get(name, default)
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"{name} must be an integer value, got {raw_value!r}.") from exc
+
+
+def _env_csv(name: str, default: str = '') -> list[str]:
+    raw_value = os.environ.get(name, default)
+    return [part.strip() for part in raw_value.split(',') if part.strip()]
 
 
 class Config:
     # Flask
+    # This secret signs login cookies. Use a random value in production.
+    # If this is weak or shared, attackers can forge sessions.
     SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-change-in-production')
-    
-    # Disable debug in production
-    DEBUG = os.environ.get('FLASK_DEBUG') == '1' or os.environ.get('FLASK_ENV') == 'development'
-    TRUST_PROXY = os.environ.get('TRUST_PROXY', '0') == '1'
 
-    # Security
+    # Debug should only be enabled for local development.
+    # Leaving debug on in production can expose sensitive internals.
+    DEBUG = os.environ.get('FLASK_DEBUG') == '1' or os.environ.get('FLASK_ENV') == 'development'
+    # Set this to 1 only when traffic comes through your own reverse proxy.
+    # If enabled on public traffic, client IP and scheme can be spoofed.
+    TRUST_PROXY = _env_bool('TRUST_PROXY', '0')
+
+    # Session Security
+    # Keep session cookies inaccessible to browser JavaScript.
+    # Turning this off increases account takeover risk from injected scripts.
     SESSION_COOKIE_HTTPONLY = True
+    # Recommended: Lax for admin apps. Strict is also valid if your UX allows it.
+    # A weaker setting can make cross-site request abuse easier.
     SESSION_COOKIE_SAMESITE = os.environ.get('SESSION_COOKIE_SAMESITE', 'Lax')
-    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', '1' if not DEBUG else '0') == '1'
+    # Recommended in production: 1. This ensures cookies are sent only over HTTPS.
+    # Setting this to 0 in production can leak session cookies over insecure transport.
+    SESSION_COOKIE_SECURE = _env_bool('SESSION_COOKIE_SECURE', '1' if not DEBUG else '0')
+
+    # Keep remember-me cookies inaccessible to browser JavaScript.
+    # Turning this off increases account takeover risk from injected scripts.
     REMEMBER_COOKIE_HTTPONLY = True
+    # Keep remember-me cookie policy aligned with the main session cookie.
     REMEMBER_COOKIE_SAMESITE = SESSION_COOKIE_SAMESITE
+    # Recommended in production: 1, so persistent login cookies require HTTPS.
     REMEMBER_COOKIE_SECURE = SESSION_COOKIE_SECURE
 
+    # Recommended: 30 minutes. This is idle timeout for signed-in sessions.
+    # If this is too long, unattended sessions remain usable for longer.
+    SESSION_IDLE_TIMEOUT_MINUTES = _env_int('SESSION_IDLE_TIMEOUT_MINUTES', '30')
+    PERMANENT_SESSION_LIFETIME = timedelta(minutes=SESSION_IDLE_TIMEOUT_MINUTES)
+
+    # Recommended: 7 days. This controls "Remember me" duration.
+    # If this is too long, stolen persistent cookies stay valid longer.
+    REMEMBER_COOKIE_DURATION_DAYS = _env_int('REMEMBER_COOKIE_DURATION_DAYS', '7')
+    REMEMBER_COOKIE_DURATION = timedelta(days=REMEMBER_COOKIE_DURATION_DAYS)
+
+    # Login Hardening
+    # Recommended: 300 seconds (5 minutes) to measure failed login bursts.
+    # Too large means old failures keep counting for too long.
+    AUTH_ATTEMPT_WINDOW_SECONDS = _env_int('AUTH_ATTEMPT_WINDOW_SECONDS', '300')
+    # Recommended: 900 seconds (15 minutes) lockout after repeated failures.
+    # Too short weakens brute-force protection; too long may block real users.
+    AUTH_LOCKOUT_SECONDS = _env_int('AUTH_LOCKOUT_SECONDS', '900')
+    # Recommended: 5 failures per username+IP before lockout logic triggers.
+    # Too high allows rapid password guessing from one source.
+    AUTH_MAX_ATTEMPTS_IP_ACCOUNT = _env_int('AUTH_MAX_ATTEMPTS_IP_ACCOUNT', '5')
+    # Recommended: 8 failures per username across all IPs.
+    # Too high allows distributed attacks against one account.
+    AUTH_MAX_ATTEMPTS_ACCOUNT = _env_int('AUTH_MAX_ATTEMPTS_ACCOUNT', '8')
+    # Recommended: 30 failures per IP across all accounts.
+    # Too high allows broad credential-stuffing from one host.
+    AUTH_MAX_ATTEMPTS_IP = _env_int('AUTH_MAX_ATTEMPTS_IP', '30')
+
+    # Password Policy
+    # Recommended: minimum 12 characters for new/updated passwords.
+    # A smaller minimum makes guessed passwords much easier.
+    AUTH_PASSWORD_MIN_LENGTH = _env_int('AUTH_PASSWORD_MIN_LENGTH', '12')
+    # Recommended in production: 1 to enforce password policy checks.
+    # Setting this to 0 allows weak passwords to be created in the UI.
+    AUTH_PASSWORD_POLICY_ENFORCE = _env_bool('AUTH_PASSWORD_POLICY_ENFORCE', '1')
+
+    # Proxy / Host
+    # Set your allowed production hostnames (comma-separated), e.g. sms.example.com.
+    # Leaving this empty in production can allow unsafe Host header usage.
+    TRUSTED_HOSTS = _env_csv('TRUSTED_HOSTS', '')
+
     # Scheduler (disable by default in production; run as a separate service)
-    SCHEDULER_ENABLED = os.environ.get('SCHEDULER_ENABLED', '1' if DEBUG else '0') == '1'
-    SCHEDULED_MESSAGE_MAX_LAG = int(os.environ.get('SCHEDULED_MESSAGE_MAX_LAG', '1440'))
+    SCHEDULER_ENABLED = _env_bool('SCHEDULER_ENABLED', '1' if DEBUG else '0')
+    SCHEDULED_MESSAGE_MAX_LAG = _env_int('SCHEDULED_MESSAGE_MAX_LAG', '1440')
 
     APP_TIMEZONE = os.environ.get('APP_TIMEZONE', 'UTC')
 
@@ -40,7 +114,7 @@ class Config:
     }
     if str(SQLALCHEMY_DATABASE_URI).startswith('sqlite'):
         SQLALCHEMY_ENGINE_OPTIONS['connect_args'] = {
-            'timeout': int(os.environ.get('SQLITE_TIMEOUT', '30')),
+            'timeout': _env_int('SQLITE_TIMEOUT', '30'),
         }
     
     # Twilio

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -7,6 +7,7 @@ Debian VPS deployment via systemd + Nginx + Gunicorn. CI via GitHub Actions.
 ```
 deploy/
 ├── install.sh              # Automated deploy: deps, env, migrations, systemd setup
+├── deploy_sms_admin.sh     # Pull/update/migrate/restart deploy helper (+ security env append)
 ├── sms.service             # systemd: Gunicorn web app (ExecStartPre runs dbdoctor)
 ├── sms-worker.service      # systemd: RQ background worker
 ├── sms-scheduler.service   # systemd: Oneshot scheduler (triggered by timer)
@@ -29,7 +30,7 @@ deploy/
 ## CI PIPELINE (.github/workflows/deploy.yml)
 
 - Triggers on push to `main` or manual dispatch
-- SSH to VPS → run deploy script → verify services → health check
+- SSH to VPS → install `deploy/deploy_sms_admin.sh` to `/usr/local/bin/deploy_sms_admin.sh` → run deploy script → verify services → health check
 - Post-deploy assertions: services active, timer configured, scheduler runs, health endpoint 200
 
 ## CONVENTIONS

--- a/deploy/deploy_sms_admin.sh
+++ b/deploy/deploy_sms_admin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT="/opt/sms-admin"
+APP_USER="smsadmin"
+ENV_FILE="${APP_ROOT}/.env"
+VENV_BIN="${APP_ROOT}/venv/bin"
+DBDOCTOR_BIN="/usr/local/bin/dbdoctor"
+DEFAULT_TRUSTED_HOSTS="${DEFAULT_TRUSTED_HOSTS:-sms.theitwingman.com}"
+APPENDED_KEYS=0
+EXISTING_KEYS=0
+WARNING_KEYS=0
+
+ensure_env_key() {
+  local key="$1"
+  local value="$2"
+  if ! sudo grep -qE "^${key}=" "${ENV_FILE}"; then
+    echo "${key}=${value}" | sudo tee -a "${ENV_FILE}" >/dev/null
+    APPENDED_KEYS=$((APPENDED_KEYS + 1))
+    echo "[append] missing security key: ${key}"
+    return
+  fi
+  EXISTING_KEYS=$((EXISTING_KEYS + 1))
+  echo "[keep] security key already present: ${key}"
+}
+
+current_env_value() {
+  local key="$1"
+  local line
+  line="$(sudo grep -E "^${key}=" "${ENV_FILE}" | tail -n1 || true)"
+  if [[ -z "${line}" ]]; then
+    echo ""
+    return
+  fi
+  echo "${line#*=}"
+}
+
+warn_if_non_recommended() {
+  local key="$1"
+  local recommended="$2"
+  local current
+  current="$(current_env_value "${key}")"
+  if [[ -z "${current}" ]]; then
+    return
+  fi
+  if [[ "${current}" != "${recommended}" ]]; then
+    WARNING_KEYS=$((WARNING_KEYS + 1))
+    echo "[warn] ${key} is set to '${current}'. Recommended value is '${recommended}'."
+  fi
+}
+
+echo "==> Deploy script: update code + ensure security hardening config + restart"
+
+sudo touch "${ENV_FILE}"
+sudo chown root:smsadmin "${ENV_FILE}"
+sudo chmod 660 "${ENV_FILE}"
+
+echo "==> Updating repository"
+sudo -u "${APP_USER}" bash -c "cd \"${APP_ROOT}\" && git pull --ff-only"
+
+echo "==> Ensuring hardening env keys (append-only)"
+ensure_env_key "AUTH_ATTEMPT_WINDOW_SECONDS" "300"
+ensure_env_key "AUTH_LOCKOUT_SECONDS" "900"
+ensure_env_key "AUTH_MAX_ATTEMPTS_IP_ACCOUNT" "5"
+ensure_env_key "AUTH_MAX_ATTEMPTS_ACCOUNT" "8"
+ensure_env_key "AUTH_MAX_ATTEMPTS_IP" "30"
+ensure_env_key "SESSION_IDLE_TIMEOUT_MINUTES" "30"
+ensure_env_key "REMEMBER_COOKIE_DURATION_DAYS" "7"
+ensure_env_key "AUTH_PASSWORD_MIN_LENGTH" "12"
+ensure_env_key "AUTH_PASSWORD_POLICY_ENFORCE" "1"
+ensure_env_key "TRUSTED_HOSTS" "${DEFAULT_TRUSTED_HOSTS}"
+
+echo "==> Warning check for non-recommended hardening values"
+warn_if_non_recommended "AUTH_ATTEMPT_WINDOW_SECONDS" "300"
+warn_if_non_recommended "AUTH_LOCKOUT_SECONDS" "900"
+warn_if_non_recommended "AUTH_MAX_ATTEMPTS_IP_ACCOUNT" "5"
+warn_if_non_recommended "AUTH_MAX_ATTEMPTS_ACCOUNT" "8"
+warn_if_non_recommended "AUTH_MAX_ATTEMPTS_IP" "30"
+warn_if_non_recommended "SESSION_IDLE_TIMEOUT_MINUTES" "30"
+warn_if_non_recommended "REMEMBER_COOKIE_DURATION_DAYS" "7"
+warn_if_non_recommended "AUTH_PASSWORD_MIN_LENGTH" "12"
+warn_if_non_recommended "AUTH_PASSWORD_POLICY_ENFORCE" "1"
+warn_if_non_recommended "TRUSTED_HOSTS" "${DEFAULT_TRUSTED_HOSTS}"
+echo "==> Security env sync summary: appended=${APPENDED_KEYS} existing=${EXISTING_KEYS} warnings=${WARNING_KEYS}"
+
+echo "==> Installing dependencies"
+sudo -u "${APP_USER}" "${VENV_BIN}/pip" install -r "${APP_ROOT}/requirements.txt"
+
+echo "==> Applying database migrations"
+sudo -u "${APP_USER}" bash -c "cd \"${APP_ROOT}\" && \"${DBDOCTOR_BIN}\" --apply"
+
+echo "==> Restarting services"
+sudo systemctl restart sms sms-worker
+sudo systemctl restart sms-scheduler.timer
+
+echo "==> Quick health check"
+curl -fsS http://127.0.0.1:8000/health >/dev/null
+
+echo "Deploy script completed successfully."

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -275,19 +275,11 @@ sudo -u smsadmin dbdoctor --doctor
 ## Updating
 
 ```bash
-cd /opt/sms-admin
-
-# Pull latest code
-sudo -u smsadmin git pull
-
-# Update dependencies
-sudo -u smsadmin bash -c 'source venv/bin/activate && pip install -r requirements.txt'
-
-# Apply migrations
-sudo -u smsadmin dbdoctor --apply
-
-# Restart services
-sudo systemctl restart sms sms-worker
+# Recommended: use the deploy helper installed from this repo.
+# It pulls latest code, appends missing security hardening env keys,
+# warns on non-recommended existing values, installs dependencies,
+# applies migrations, and restarts services.
+sudo /usr/local/bin/deploy_sms_admin.sh
 ```
 
 ## Backup

--- a/docs/security-hardening-summary.md
+++ b/docs/security-hardening-summary.md
@@ -1,0 +1,82 @@
+# Security Hardening Summary
+
+## Scope
+This branch hardens authentication/session configuration, production validation, deployment env synchronization, and local test reliability.
+
+## What Changed
+
+### 1) Config hardening defaults and documentation
+- Added security-focused config keys in `app/config.py`:
+  - `AUTH_ATTEMPT_WINDOW_SECONDS`
+  - `AUTH_LOCKOUT_SECONDS`
+  - `AUTH_MAX_ATTEMPTS_IP_ACCOUNT`
+  - `AUTH_MAX_ATTEMPTS_ACCOUNT`
+  - `AUTH_MAX_ATTEMPTS_IP`
+  - `SESSION_IDLE_TIMEOUT_MINUTES`
+  - `REMEMBER_COOKIE_DURATION_DAYS`
+  - `AUTH_PASSWORD_MIN_LENGTH`
+  - `AUTH_PASSWORD_POLICY_ENFORCE`
+  - `TRUSTED_HOSTS`
+- Added plain-English comments above security variables for non-technical operators.
+
+### 2) Production fail-closed validation
+- Added production config validation in `app/__init__.py`:
+  - secure cookie expectations
+  - integer/range validation for hardening keys
+  - relational constraints for login limits
+  - non-empty trusted hosts requirement
+- Production startup now raises a clear runtime error if critical security config is invalid.
+
+### 3) Login hardening now uses config values
+- Updated `app/auth.py` rate-limiting to read config keys dynamically.
+- Added layered counters for:
+  - IP
+  - account
+  - IP+account
+- Preserved legacy key compatibility where needed.
+
+### 4) Password policy enforcement
+- Added password policy checks in user create/edit flows and account password change.
+- Policy is config-driven (`AUTH_PASSWORD_MIN_LENGTH`, `AUTH_PASSWORD_POLICY_ENFORCE`).
+
+### 5) Bootstrap secret cleanup (new)
+- Added automatic cleanup of `ADMIN_PASSWORD` after a successful admin password change in production.
+- Implemented in `app/routes.py`:
+  - Runs only when:
+    - `FLASK_ENV=production`
+    - `DEBUG` is false
+    - current user matches `ADMIN_USERNAME`
+  - Removes `ADMIN_PASSWORD=` from env file (default `/opt/sms-admin/.env`, override `SMS_ADMIN_ENV_FILE`).
+  - Clears in-process `os.environ["ADMIN_PASSWORD"]` and app config value.
+- Added regression test in `tests/test_password_change.py`.
+
+### 6) Deployment env sync safety
+- Added deploy script `deploy/deploy_sms_admin.sh` to:
+  - append missing hardening keys only
+  - preserve existing keys
+  - warn when existing values are weaker/non-recommended
+  - print sync summary (`appended`, `existing`, `warnings`)
+- Updated workflow/deploy docs accordingly.
+
+### 7) Local test reliability
+- Added `run/test.sh` wrapper to keep test runs isolated to this repo.
+- Ensures `venv`/dependencies are present and Python version is correct.
+- Supports option-only invocations (for example `-q`, `--cov=app`) without collecting unrelated nested test directories.
+- `run/setup.sh` now installs `pytest` and `pytest-cov`.
+
+## Recommended Production Values
+- `AUTH_ATTEMPT_WINDOW_SECONDS=300`
+- `AUTH_LOCKOUT_SECONDS=900`
+- `AUTH_MAX_ATTEMPTS_IP_ACCOUNT=5`
+- `AUTH_MAX_ATTEMPTS_ACCOUNT=8`
+- `AUTH_MAX_ATTEMPTS_IP=30`
+- `SESSION_IDLE_TIMEOUT_MINUTES=30`
+- `REMEMBER_COOKIE_DURATION_DAYS=7`
+- `AUTH_PASSWORD_MIN_LENGTH=12`
+- `AUTH_PASSWORD_POLICY_ENFORCE=1`
+- `TRUSTED_HOSTS=<your production domain list>`
+
+## Operational Notes
+- `SECRET_KEY` must always be provided in production `.env`; fallback default is for local/dev only.
+- Rotating `SECRET_KEY` invalidates active sessions.
+- `ADMIN_PASSWORD` should be treated as bootstrap-only; this branch automates its removal after first successful admin password update in production.

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -43,7 +43,8 @@ if [[ "${VENV_PYTHON_VERSION}" != "${REQUIRED_PYTHON}" ]]; then
 fi
 
 "${PYTHON_BIN}" -m pip install -r "${REPO_ROOT}/requirements.txt"
-echo "Installed Python dependencies."
+"${PYTHON_BIN}" -m pip install pytest pytest-cov
+echo "Installed Python dependencies, pytest, and pytest-cov."
 
 if [[ -f "${ENV_FILE}" ]]; then
   echo "Keeping existing .env file."
@@ -61,5 +62,6 @@ cat <<'EOF'
 Next steps:
 1. Edit .env with your credentials.
 2. Activate venv: source venv/bin/activate
-3. Run the app: flask --app wsgi:app run --debug
+3. Run tests: ./run/test.sh
+4. Run the app: flask --app wsgi:app run --debug
 EOF

--- a/run/test.sh
+++ b/run/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${REPO_ROOT}/venv"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+REQUIRED_PYTHON="3.11"
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "Local venv is missing. Bootstrapping with ./run/setup.sh ..."
+  "${REPO_ROOT}/run/setup.sh"
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "ERROR: venv not found at ${PYTHON_BIN} after setup." >&2
+  exit 1
+fi
+
+VENV_PYTHON_VERSION="$("${PYTHON_BIN}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+if [[ "${VENV_PYTHON_VERSION}" != "${REQUIRED_PYTHON}" ]]; then
+  echo "ERROR: venv uses Python ${VENV_PYTHON_VERSION}; expected ${REQUIRED_PYTHON}." >&2
+  echo "Recreate it with: rm -rf ${VENV_DIR} && ./run/setup.sh" >&2
+  exit 1
+fi
+
+if ! "${PYTHON_BIN}" - <<'PY' >/dev/null 2>&1
+import flask
+import flask_sqlalchemy
+import flask_login
+import flask_wtf
+import sqlalchemy
+import pytest
+import pytest_cov
+PY
+then
+  echo "Missing test/runtime dependencies in venv. Installing requirements + pytest tooling ..."
+  "${PYTHON_BIN}" -m pip install -r "${REPO_ROOT}/requirements.txt"
+  "${PYTHON_BIN}" -m pip install pytest pytest-cov
+fi
+
+unset PYTHONPATH
+cd "${REPO_ROOT}"
+
+has_target_path=0
+for arg in "$@"; do
+  if [[ "${arg}" != -* ]]; then
+    has_target_path=1
+    break
+  fi
+done
+
+if [[ "$#" -eq 0 || "${has_target_path}" -eq 0 ]]; then
+  exec "${PYTHON_BIN}" -m pytest --import-mode=importlib tests "$@"
+fi
+
+exec "${PYTHON_BIN}" -m pytest --import-mode=importlib "$@"

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,0 +1,95 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestConfigSecurityHardening(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_env = os.environ.copy()
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "config-security.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+        os.environ.pop("FLASK_DEBUG", None)
+        os.environ.pop("FLASK_ENV", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._original_env)
+        self._temp_dir.cleanup()
+
+    def _reload_config_module(self):
+        import app.config
+
+        importlib.reload(app.config)
+        return app.config
+
+    def test_recommended_hardening_defaults(self) -> None:
+        config_module = self._reload_config_module()
+        Config = config_module.Config
+
+        self.assertEqual(Config.AUTH_ATTEMPT_WINDOW_SECONDS, 300)
+        self.assertEqual(Config.AUTH_LOCKOUT_SECONDS, 900)
+        self.assertEqual(Config.AUTH_MAX_ATTEMPTS_IP_ACCOUNT, 5)
+        self.assertEqual(Config.AUTH_MAX_ATTEMPTS_ACCOUNT, 8)
+        self.assertEqual(Config.AUTH_MAX_ATTEMPTS_IP, 30)
+        self.assertEqual(Config.SESSION_IDLE_TIMEOUT_MINUTES, 30)
+        self.assertEqual(Config.REMEMBER_COOKIE_DURATION_DAYS, 7)
+        self.assertEqual(Config.AUTH_PASSWORD_MIN_LENGTH, 12)
+        self.assertTrue(Config.AUTH_PASSWORD_POLICY_ENFORCE)
+
+    def test_invalid_integer_config_raises_clear_error(self) -> None:
+        os.environ["AUTH_LOCKOUT_SECONDS"] = "not-a-number"
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reload_config_module()
+
+        self.assertIn("AUTH_LOCKOUT_SECONDS must be an integer", str(ctx.exception))
+
+    def test_production_requires_trusted_hosts(self) -> None:
+        os.environ["FLASK_ENV"] = "production"
+        os.environ["SECRET_KEY"] = "test-production-secret-key"
+        os.environ.pop("TRUSTED_HOSTS", None)
+
+        self._reload_config_module()
+
+        from app import create_app
+
+        with self.assertRaises(RuntimeError) as ctx:
+            create_app(run_startup_tasks=False, start_scheduler=False)
+
+        self.assertIn("TRUSTED_HOSTS must include your production hostnames", str(ctx.exception))
+
+    def test_security_variables_have_non_technical_comments(self) -> None:
+        config_path = os.path.join(os.path.dirname(__file__), "..", "app", "config.py")
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            lines = config_file.read().splitlines()
+
+        security_variable_names = [
+            "SECRET_KEY =",
+            "TRUST_PROXY =",
+            "SESSION_COOKIE_SAMESITE =",
+            "SESSION_COOKIE_SECURE =",
+            "SESSION_IDLE_TIMEOUT_MINUTES =",
+            "REMEMBER_COOKIE_DURATION_DAYS =",
+            "AUTH_ATTEMPT_WINDOW_SECONDS =",
+            "AUTH_LOCKOUT_SECONDS =",
+            "AUTH_MAX_ATTEMPTS_IP_ACCOUNT =",
+            "AUTH_MAX_ATTEMPTS_ACCOUNT =",
+            "AUTH_MAX_ATTEMPTS_IP =",
+            "AUTH_PASSWORD_MIN_LENGTH =",
+            "AUTH_PASSWORD_POLICY_ENFORCE =",
+            "TRUSTED_HOSTS =",
+        ]
+
+        for index, line in enumerate(lines):
+            if any(name in line for name in security_variable_names):
+                previous_line = lines[index - 1].strip() if index > 0 else ""
+                self.assertTrue(
+                    previous_line.startswith("#"),
+                    f"Expected a plain-language comment directly above: {line.strip()}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_login_hardening_config.py
+++ b/tests/test_login_hardening_config.py
@@ -1,0 +1,91 @@
+import os
+import tempfile
+import unittest
+
+
+class TestLoginHardeningConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_env = os.environ.copy()
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "login-hardening.db")
+
+        os.environ["FLASK_DEBUG"] = "1"
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+        os.environ["AUTH_ATTEMPT_WINDOW_SECONDS"] = "300"
+        os.environ["AUTH_LOCKOUT_SECONDS"] = "900"
+        os.environ["AUTH_MAX_ATTEMPTS_IP_ACCOUNT"] = "5"
+        os.environ["AUTH_MAX_ATTEMPTS_ACCOUNT"] = "8"
+        os.environ["AUTH_MAX_ATTEMPTS_IP"] = "30"
+
+        import importlib
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser
+
+        self.db = db
+        self.AppUser = AppUser
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+
+        self._ctx = self.app.app_context()
+        self._ctx.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        user = self.AppUser(username="admin", role="admin", must_change_password=False)
+        user.set_password("correct-password-123")
+        self.db.session.add(user)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._ctx.pop()
+        self._temp_dir.cleanup()
+        os.environ.clear()
+        os.environ.update(self._original_env)
+
+    def _post_login(self, username: str, password: str):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=True,
+        )
+
+    def test_ip_limit_from_config_is_applied(self) -> None:
+        os.environ["AUTH_MAX_ATTEMPTS_IP"] = "2"
+        import importlib
+        import app.config
+
+        importlib.reload(app.config)
+        self.app.config["AUTH_MAX_ATTEMPTS_IP"] = 2
+
+        self._post_login("admin", "wrong-pass")
+        self._post_login("admin", "wrong-pass")
+        response = self._post_login("admin", "wrong-pass")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Too many failed attempts", response.data)
+
+    def test_account_limit_from_config_is_applied(self) -> None:
+        os.environ["AUTH_MAX_ATTEMPTS_ACCOUNT"] = "1"
+        os.environ["AUTH_MAX_ATTEMPTS_IP"] = "30"
+        import importlib
+        import app.config
+
+        importlib.reload(app.config)
+        self.app.config["AUTH_MAX_ATTEMPTS_ACCOUNT"] = 1
+        self.app.config["AUTH_MAX_ATTEMPTS_IP"] = 30
+
+        self._post_login("admin", "wrong-pass")
+        response = self._post_login("admin", "wrong-pass")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Too many failed attempts", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -6,6 +6,8 @@ import unittest
 class TestPasswordChangeFlow(unittest.TestCase):
     def setUp(self) -> None:
         self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        self._original_flask_env = os.environ.get("FLASK_ENV")
+        self._original_sms_admin_env_file = os.environ.get("SMS_ADMIN_ENV_FILE")
         os.environ["FLASK_DEBUG"] = "1"
         self._temp_dir = tempfile.TemporaryDirectory()
         db_path = os.path.join(self._temp_dir.name, "test.db")
@@ -44,6 +46,14 @@ class TestPasswordChangeFlow(unittest.TestCase):
             os.environ.pop("FLASK_DEBUG", None)
         else:
             os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        if self._original_flask_env is None:
+            os.environ.pop("FLASK_ENV", None)
+        else:
+            os.environ["FLASK_ENV"] = self._original_flask_env
+        if self._original_sms_admin_env_file is None:
+            os.environ.pop("SMS_ADMIN_ENV_FILE", None)
+        else:
+            os.environ["SMS_ADMIN_ENV_FILE"] = self._original_sms_admin_env_file
         os.environ.pop("DATABASE_URL", None)
 
     def _login(self, password: str) -> None:
@@ -96,6 +106,40 @@ class TestPasswordChangeFlow(unittest.TestCase):
         user = self.AppUser.query.filter_by(username="forced").first()
         self.assertIsNotNone(user)
         self.assertTrue(user.must_change_password)
+
+    def test_production_change_removes_bootstrap_admin_password_from_env_file(self) -> None:
+        env_path = os.path.join(self._temp_dir.name, "prod.env")
+        with open(env_path, "w", encoding="utf-8") as env_file:
+            env_file.write("FLASK_ENV=production\n")
+            env_file.write("ADMIN_USERNAME=forced\n")
+            env_file.write("ADMIN_PASSWORD=bootstrap-secret\n")
+            env_file.write("OTHER_KEY=keep\n")
+
+        os.environ["FLASK_ENV"] = "production"
+        os.environ["SMS_ADMIN_ENV_FILE"] = env_path
+        os.environ["ADMIN_PASSWORD"] = "bootstrap-secret"
+        self.app.config["DEBUG"] = False
+        self.app.config["ADMIN_USERNAME"] = "forced"
+        self.app.config["ADMIN_PASSWORD"] = "bootstrap-secret"
+
+        self._login("old-password")
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "old-password",
+                "new_password": "new-password-123",
+                "confirm_password": "new-password-123",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        with open(env_path, "r", encoding="utf-8") as env_file:
+            env_contents = env_file.read()
+        self.assertNotIn("ADMIN_PASSWORD=", env_contents)
+        self.assertIn("OTHER_KEY=keep", env_contents)
+        self.assertIsNone(os.environ.get("ADMIN_PASSWORD"))
+        self.assertIsNone(self.app.config.get("ADMIN_PASSWORD"))
 
 
 if __name__ == "__main__":

--- a/tests/test_user_creation.py
+++ b/tests/test_user_creation.py
@@ -60,7 +60,7 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
             data={
                 "username": "new-user",
                 "role": "social_manager",
-                "password": "new-pass",
+                "password": "new-password-123",
             },
             follow_redirects=False,
         )
@@ -77,7 +77,7 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
             data={
                 "username": "new-user-2",
                 "role": "social_manager",
-                "password": "new-pass",
+                "password": "new-password-123",
                 "must_change_password": "on",
             },
             follow_redirects=False,


### PR DESCRIPTION
## Summary
This PR hardens production auth/session security, adds config validation, improves deploy-time env safety, and adds local test reliability improvements.

## Security Changes
- Added new hardening config keys with plain-English comments:
  - `AUTH_ATTEMPT_WINDOW_SECONDS`
  - `AUTH_LOCKOUT_SECONDS`
  - `AUTH_MAX_ATTEMPTS_IP_ACCOUNT`
  - `AUTH_MAX_ATTEMPTS_ACCOUNT`
  - `AUTH_MAX_ATTEMPTS_IP`
  - `SESSION_IDLE_TIMEOUT_MINUTES`
  - `REMEMBER_COOKIE_DURATION_DAYS`
  - `AUTH_PASSWORD_MIN_LENGTH`
  - `AUTH_PASSWORD_POLICY_ENFORCE`
  - `TRUSTED_HOSTS`
- Added production fail-closed validation for critical security config.
- Added trusted host enforcement in explicit production mode.
- Updated login throttling to use config-driven limits (IP, account, IP+account).
- Enforced password policy in user create/edit and account password change flows.
- Added automatic bootstrap cleanup:
  - After successful admin password change in production, remove `ADMIN_PASSWORD` from `.env`.
  - Clears in-process `ADMIN_PASSWORD` value as well.

## Deploy/Operations Changes
- Added `deploy/deploy_sms_admin.sh`:
  - appends only missing hardening env keys
  - preserves existing env values
  - prints warnings for non-recommended values
  - prints summary counts (appended/existing/warnings)
- Updated deploy workflow and docs to align with this script.
- Updated `.env.example` and configuration docs with recommended values.

## Local Test Reliability
- Added `run/test.sh` wrapper:
  - enforces local venv and Python 3.11
  - auto-installs missing test tooling
  - runs repo-local tests safely (including option-only args like `-q` / `--cov=app`)
- Updated `run/setup.sh` to install `pytest` + `pytest-cov`.
- Updated README testing instructions.

## Documentation
- Added security rollout summary doc:
  - `docs/security-hardening-summary.md`

## Validation
- `./run/test.sh -q` -> `154 passed`
- Targeted tests added/updated for:
  - config hardening validation
  - login hardening behavior
  - production bootstrap `ADMIN_PASSWORD` cleanup on password change

## Notes
- Existing production env values are preserved (`append missing + warn`).
- `SECRET_KEY` remains required in production env and should be rotated safely when needed.
