### PR TITLE
Follow-up: enforce permanent sessions for idle timeout hardening

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin, urlparse
 from functools import wraps
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, current_app
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, current_app, session
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
 from app import db
 from app.models import AppUser, LoginAttempt
@@ -149,6 +149,9 @@ def require_roles(*roles):
 
 @bp.before_app_request
 def enforce_password_change():
+    if current_user.is_authenticated:
+        session.permanent = True
+
     if not current_user.is_authenticated:
         return None
     if not current_user.must_change_password:

--- a/tests/test_login_hardening_config.py
+++ b/tests/test_login_hardening_config.py
@@ -86,6 +86,13 @@ class TestLoginHardeningConfig(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Too many failed attempts", response.data)
 
+    def test_successful_login_marks_session_permanent(self) -> None:
+        response = self._post_login("admin", "correct-password-123")
+
+        self.assertEqual(response.status_code, 200)
+        with self.client.session_transaction() as session:
+            self.assertTrue(session.permanent)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- The configured `SESSION_IDLE_TIMEOUT_MINUTES` / `PERMANENT_SESSION_LIFETIME` was not applied to normal authenticated sessions because `session.permanent` was never set, so the idle-timeout hardening had no runtime effect.

### Description
- Mark authenticated sessions as permanent by setting `session.permanent = True` in the `@bp.before_app_request` hook in `app/auth.py` so Flask will apply `PERMANENT_SESSION_LIFETIME` to active logins.
- Add a regression test `test_successful_login_marks_session_permanent` in `tests/test_login_hardening_config.py` that logs in and asserts the session is permanent.

### Testing
- Ran `pytest -q tests/test_login_hardening_config.py` which passed: `3 passed`.
- Ran `pytest -q tests/test_config_security.py tests/test_login_hardening_config.py` which passed: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69998d1c0808832492707f1aca19eed3)