### PR TITLE
Auth hardening rollout: session nonce revocation, lockout audit, and Phase 4 completion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,12 @@ SCHEDULER_ENABLED=0
 # AUTH_PASSWORD_POLICY_ENFORCE=1
 # Comma-separated hostnames allowed in production requests (recommended: your real domain)
 # TRUSTED_HOSTS=sms.theitwingman.com
+
+# Auth event + password-history hardening controls
+# PASSWORD_HISTORY_COUNT=3
+# AUTH_ALERTS_ENABLED=1
+# AUTH_EVENT_RETENTION_DAYS=180
+
+# Alias settings for auth lockout service (defaults map to the login hardening settings above)
+# AUTH_LOCKOUT_MAX_ATTEMPTS=5
+# AUTH_LOCKOUT_WINDOW_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A production-ready, single-user SMS admin web application for sending community 
 - **Automatic Suppression**: Auto-detect and suppress invalid numbers and opt-outs
 - **Unsubscribe Management**: Track and respect opt-outs across all sends
 - **Role-Based Access**: Admin and social manager roles with appropriate permissions
+- **Security Hardening**: Password complexity/reuse controls, account lockout tracking, nonce-based session revocation, and security audit events
 - **Secure**: Environment-based secrets, Flask-Login authentication, CSRF protection, HTTPS
 
 ## Documentation

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,137 +1,40 @@
-from datetime import datetime, timedelta, timezone
-from urllib.parse import urljoin, urlparse
 from functools import wraps
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, current_app, session
-from flask_login import LoginManager, login_user, logout_user, login_required, current_user
+from urllib.parse import urljoin, urlparse
+
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
+from flask_login import LoginManager, current_user, login_required, login_user, logout_user
+
 from app import db
-from app.models import AppUser, LoginAttempt
+from app.models import AppUser
+from app.services.auth_security_service import (
+    check_login_limited,
+    clear_failed_logins,
+    normalize_login_username,
+    record_auth_event,
+    record_failed_login,
+)
+from app.services.security_alert_service import send_security_alert
+
 
 login_manager = LoginManager()
-login_manager.login_view = 'auth.login'
+login_manager.login_view = "auth.login"
 login_manager.login_message = None
-login_manager.login_message_category = 'warning'
+login_manager.login_message_category = "warning"
+login_manager.session_protection = "strong"
 
-bp = Blueprint('auth', __name__)
-
-
-def _get_client_ip():
-    return request.remote_addr or 'unknown'
+bp = Blueprint("auth", __name__)
 
 
-def _normalize_username(username: str | None) -> str:
-    return (username or '').strip().lower()
+def _get_client_ip() -> str:
+    return request.remote_addr or "unknown"
 
 
-def _attempt_window_seconds() -> int:
-    return int(current_app.config.get('AUTH_ATTEMPT_WINDOW_SECONDS', 300))
-
-
-def _lockout_seconds() -> int:
-    return int(current_app.config.get('AUTH_LOCKOUT_SECONDS', 900))
-
-
-def _keys_for_login_attempt(username: str | None, include_legacy_ip: bool = False) -> list[str]:
-    client_ip = _get_client_ip()
-    normalized_username = _normalize_username(username)
-
-    keys = [f'ip:{client_ip}']
-    if include_legacy_ip:
-        keys.append(client_ip)
-    if normalized_username:
-        keys.append(f'account:{normalized_username}')
-        keys.append(f'ip_account:{client_ip}:{normalized_username}')
-    return keys
-
-
-def _attempt_limit_for_key(key: str) -> int:
-    if key.startswith('ip_account:'):
-        return int(current_app.config.get('AUTH_MAX_ATTEMPTS_IP_ACCOUNT', 5))
-    if key.startswith('account:'):
-        return int(current_app.config.get('AUTH_MAX_ATTEMPTS_ACCOUNT', 8))
-    return int(current_app.config.get('AUTH_MAX_ATTEMPTS_IP', 30))
-
-
-def _is_safe_url(target):
+def _is_safe_url(target: str | None) -> bool:
     if not target:
         return False
     host_url = urlparse(request.host_url)
     redirect_url = urlparse(urljoin(request.host_url, target))
-    return redirect_url.scheme in ('http', 'https') and host_url.netloc == redirect_url.netloc
-
-
-def _login_rate_limited(username: str | None):
-    now = datetime.now(timezone.utc)
-    lockout_seconds = _lockout_seconds()
-    attempt_window_seconds = _attempt_window_seconds()
-
-    keys = _keys_for_login_attempt(username, include_legacy_ip=True)
-    records = LoginAttempt.query.filter(LoginAttempt.client_ip.in_(keys)).all()
-
-    records_to_delete = []
-    record_changed = False
-    max_remaining = 0.0
-
-    for record in records:
-        if record.locked_until:
-            locked_until = record.locked_until.replace(tzinfo=timezone.utc)
-            if now < locked_until:
-                remaining = (locked_until - now).total_seconds()
-                max_remaining = max(max_remaining, remaining)
-                continue
-
-            records_to_delete.append(record)
-            continue
-
-        first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
-        if (now - first_attempt).total_seconds() > attempt_window_seconds:
-            records_to_delete.append(record)
-            continue
-
-        max_attempts = _attempt_limit_for_key(record.client_ip)
-        if record.attempt_count >= max_attempts:
-            record.locked_until = now + timedelta(seconds=lockout_seconds)
-            record_changed = True
-            max_remaining = max(max_remaining, float(lockout_seconds))
-
-    for record in records_to_delete:
-        db.session.delete(record)
-        record_changed = True
-
-    if record_changed:
-        db.session.commit()
-
-    if max_remaining > 0:
-        return True, max_remaining
-
-    return False, None
-
-
-def _record_failed_login(username: str | None):
-    now = datetime.now(timezone.utc)
-    attempt_window_seconds = _attempt_window_seconds()
-
-    for key in _keys_for_login_attempt(username):
-        record = LoginAttempt.query.filter_by(client_ip=key).first()
-        if not record:
-            record = LoginAttempt(client_ip=key, attempt_count=1, first_attempt_at=now)
-            db.session.add(record)
-            continue
-
-        first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
-        if (now - first_attempt).total_seconds() > attempt_window_seconds:
-            record.attempt_count = 1
-            record.first_attempt_at = now
-            record.locked_until = None
-        else:
-            record.attempt_count += 1
-
-    db.session.commit()
-
-
-def _clear_failed_logins(username: str | None):
-    keys = _keys_for_login_attempt(username, include_legacy_ip=True)
-    LoginAttempt.query.filter(LoginAttempt.client_ip.in_(keys)).delete(synchronize_session=False)
-    db.session.commit()
+    return redirect_url.scheme in ("http", "https") and host_url.netloc == redirect_url.netloc
 
 
 def require_roles(*roles):
@@ -143,73 +46,151 @@ def require_roles(*roles):
             if roles and current_user.role not in roles:
                 abort(403)
             return view(*args, **kwargs)
+
         return wrapped
+
     return decorator
 
 
 @bp.before_app_request
-def enforce_password_change():
-    if current_user.is_authenticated:
-        session.permanent = True
-
+def enforce_account_security():
     if not current_user.is_authenticated:
         return None
-    if not current_user.must_change_password:
-        return None
+
+    # Keep idle timeout enforcement active by using permanent sessions.
+    session.permanent = True
 
     endpoint = request.endpoint or ""
     if endpoint.startswith("static"):
         return None
-    if endpoint in {"auth.login", "auth.logout", "main.change_password"}:
-        return None
 
-    return redirect(url_for("main.change_password"))
+    if current_user.must_change_password:
+        allowed_endpoints = {
+            "auth.login",
+            "auth.logout",
+            "main.change_password",
+            "main.security_contact",
+        }
+        if endpoint not in allowed_endpoints:
+            return redirect(url_for("main.change_password"))
+
+    if not current_user.phone:
+        allowed_endpoints = {
+            "auth.login",
+            "auth.logout",
+            "main.security_contact",
+        }
+        if endpoint not in allowed_endpoints:
+            return redirect(url_for("main.security_contact"))
+
+    return None
 
 
 @login_manager.user_loader
 def load_user(user_id):
-    """Load user by ID."""
+    """Load user by nonce-bound session identifier."""
+    if not user_id or ":" not in user_id:
+        return None
+
+    user_id_raw, nonce = user_id.split(":", 1)
     try:
-        user_id_int = int(user_id)
+        user_id_int = int(user_id_raw)
     except (TypeError, ValueError):
         return None
-    return db.session.get(AppUser, user_id_int)
+
+    user = db.session.get(AppUser, user_id_int)
+    if not user or not user.session_nonce:
+        return None
+
+    if user.session_nonce != nonce:
+        return None
+
+    return user
 
 
-@bp.route('/login', methods=['GET', 'POST'])
+@bp.route("/login", methods=["GET", "POST"])
 def login():
-    if request.method == 'POST':
-        username = request.form.get('username', '').strip()
-        password = request.form.get('password', '')
-        remember = request.form.get('remember') == 'on'
+    if request.method == "POST":
+        username_input = request.form.get("username", "").strip()
+        normalized_username = normalize_login_username(username_input)
+        password = request.form.get("password", "")
+        remember = request.form.get("remember") == "on"
+        client_ip = _get_client_ip()
 
-        limited, remaining = _login_rate_limited(username)
+        limited, remaining_seconds, scope = check_login_limited(client_ip, normalized_username)
         if limited:
-            minutes = max(1, int(remaining // 60))
-            flash(f'Too many failed attempts. Try again in {minutes} minute(s).', 'error')
-            return render_template('auth/login.html')
+            minutes = max(1, int(((remaining_seconds or 0) + 59) // 60))
+            record_auth_event(
+                "login_blocked",
+                outcome="blocked",
+                username=normalized_username or username_input,
+                client_ip=client_ip,
+                metadata={
+                    "scope": scope,
+                    "remaining_seconds": remaining_seconds,
+                },
+            )
+            flash(f"Too many failed attempts. Try again in {minutes} minute(s).", "error")
+            return render_template("auth/login.html")
 
-        user = AppUser.query.filter_by(username=username).first()
+        user = AppUser.query.filter_by(username=username_input).first()
 
         if user and user.check_password(password):
+            # Clear existing client session before issuing a new authenticated session.
+            session.clear()
             login_user(user, remember=remember)
-            _clear_failed_logins(username)
+            clear_failed_logins(client_ip, normalize_login_username(user.username))
+            record_auth_event(
+                "login_success",
+                outcome="success",
+                user=user,
+                username=user.username,
+                client_ip=client_ip,
+                metadata={"remember": remember},
+            )
+
             if user.must_change_password:
-                return redirect(url_for('main.change_password'))
-            next_page = request.args.get('next')
+                return redirect(url_for("main.change_password"))
+
+            next_page = request.args.get("next")
             if next_page and _is_safe_url(next_page):
                 return redirect(next_page)
-            return redirect(url_for('main.dashboard'))
+            return redirect(url_for("main.dashboard"))
 
-        _record_failed_login(username)
-        flash('Invalid username or password.', 'error')
-    
-    return render_template('auth/login.html')
+        lock_result = record_failed_login(client_ip, normalized_username)
+        record_auth_event(
+            "login_failure",
+            outcome="failed",
+            username=normalized_username or username_input,
+            client_ip=client_ip,
+            metadata=lock_result,
+        )
+
+        if user and lock_result.get("account_locked_now"):
+            alert_result = send_security_alert(user, "account_lockout")
+            if not alert_result.get("success"):
+                record_auth_event(
+                    "alert_sms_failed",
+                    outcome="failed",
+                    user=user,
+                    username=user.username,
+                    client_ip=client_ip,
+                    metadata={
+                        "context": "account_lockout",
+                        "reason": alert_result.get("reason"),
+                        "skipped": alert_result.get("skipped", False),
+                    },
+                )
+
+        flash("Invalid username or password.", "error")
+
+    return render_template("auth/login.html")
 
 
-@bp.route('/logout')
+@bp.route("/logout", methods=["POST"])
 @login_required
 def logout():
     logout_user()
-    flash('You have been logged out.', 'success')
-    return redirect(url_for('auth.login'))
+    session.clear()
+    flash("You have been logged out.", "success")
+    return redirect(url_for("auth.login"))

--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,14 @@ class Config:
     # Setting this to 0 allows weak passwords to be created in the UI.
     AUTH_PASSWORD_POLICY_ENFORCE = _env_bool('AUTH_PASSWORD_POLICY_ENFORCE', '1')
 
+    # Auth Event / Password Hardening
+    PASSWORD_HISTORY_COUNT = _env_int('PASSWORD_HISTORY_COUNT', '3')
+    AUTH_ALERTS_ENABLED = _env_bool('AUTH_ALERTS_ENABLED', '1')
+    AUTH_EVENT_RETENTION_DAYS = _env_int('AUTH_EVENT_RETENTION_DAYS', '180')
+    # Alias settings used by the auth security service.
+    AUTH_LOCKOUT_MAX_ATTEMPTS = _env_int('AUTH_LOCKOUT_MAX_ATTEMPTS', str(AUTH_MAX_ATTEMPTS_IP_ACCOUNT))
+    AUTH_LOCKOUT_WINDOW_SECONDS = _env_int('AUTH_LOCKOUT_WINDOW_SECONDS', str(AUTH_ATTEMPT_WINDOW_SECONDS))
+
     # Proxy / Host
     # Set your allowed production hostnames (comma-separated), e.g. sms.example.com.
     # Leaving this empty in production can allow unsafe Host header usage.

--- a/app/migrations/010_add_auth_hardening_tables_and_columns.py
+++ b/app/migrations/010_add_auth_hardening_tables_and_columns.py
@@ -1,0 +1,109 @@
+from sqlalchemy import text
+
+
+def _table_columns(connection, table_name: str) -> set[str]:
+    result = connection.execute(text(f"PRAGMA table_info({table_name})"))
+    return {row._mapping["name"] for row in result}
+
+
+def apply(connection, logger) -> None:
+    users_columns = _table_columns(connection, "users")
+    if not users_columns:
+        logger.info("Skipping migration 010_add_auth_hardening_tables_and_columns: table users does not exist.")
+        return
+
+    if "phone" not in users_columns:
+        connection.execute(text("ALTER TABLE users ADD COLUMN phone VARCHAR(20)"))
+        logger.info("Migration 010: added users.phone.")
+
+    if "session_nonce" not in users_columns:
+        connection.execute(text("ALTER TABLE users ADD COLUMN session_nonce VARCHAR(64) NOT NULL DEFAULT ''"))
+        logger.info("Migration 010: added users.session_nonce.")
+
+    connection.execute(
+        text(
+            """
+            UPDATE users
+            SET session_nonce = lower(hex(randomblob(16)))
+            WHERE session_nonce IS NULL OR TRIM(session_nonce) = ''
+            """
+        )
+    )
+    connection.execute(text("CREATE INDEX IF NOT EXISTS ix_users_phone ON users (phone)"))
+    connection.execute(
+        text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_users_phone_nonempty
+            ON users (phone)
+            WHERE phone IS NOT NULL AND TRIM(phone) <> ''
+            """
+        )
+    )
+    logger.info("Migration 010: backfilled users.session_nonce and ensured users phone indexes.")
+
+    login_attempt_columns = _table_columns(connection, "login_attempts")
+    if login_attempt_columns:
+        if "username" not in login_attempt_columns:
+            connection.execute(
+                text("ALTER TABLE login_attempts ADD COLUMN username VARCHAR(80) NOT NULL DEFAULT ''")
+            )
+            logger.info("Migration 010: added login_attempts.username.")
+
+        connection.execute(
+            text("UPDATE login_attempts SET username = '' WHERE username IS NULL")
+        )
+        connection.execute(
+            text(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_login_attempts_client_ip_username
+                ON login_attempts (client_ip, username)
+                """
+            )
+        )
+        logger.info("Migration 010: normalized login_attempts.username and ensured composite index.")
+
+    connection.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS user_password_history (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                password_hash VARCHAR(255) NOT NULL,
+                created_at DATETIME NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users (id)
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS ix_user_password_history_user_created
+            ON user_password_history (user_id, created_at DESC)
+            """
+        )
+    )
+
+    connection.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS auth_events (
+                id INTEGER PRIMARY KEY,
+                event_type VARCHAR(50) NOT NULL,
+                outcome VARCHAR(20) NOT NULL DEFAULT 'success',
+                user_id INTEGER,
+                username VARCHAR(80),
+                client_ip VARCHAR(45),
+                metadata_json TEXT,
+                created_at DATETIME NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users (id)
+            )
+            """
+        )
+    )
+    connection.execute(text("CREATE INDEX IF NOT EXISTS ix_auth_events_created_at ON auth_events (created_at)"))
+    connection.execute(text("CREATE INDEX IF NOT EXISTS ix_auth_events_user_id ON auth_events (user_id)"))
+    connection.execute(text("CREATE INDEX IF NOT EXISTS ix_auth_events_event_type ON auth_events (event_type)"))
+    connection.execute(text("CREATE INDEX IF NOT EXISTS ix_auth_events_username ON auth_events (username)"))
+
+    logger.info("Migration 010_add_auth_hardening_tables_and_columns: schema updates complete.")

--- a/app/services/auth_security_service.py
+++ b/app/services/auth_security_service.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from flask import current_app
+from sqlalchemy.exc import SQLAlchemyError
+from werkzeug.security import check_password_hash
+
+from app import db
+from app.config import Config as AppConfig
+from app.models import AuthEvent, LoginAttempt, UserPasswordHistory
+
+
+ACCOUNT_SCOPE_IP = "__account__"
+IP_SCOPE_USERNAME = ""
+
+_LAST_PRUNE_DATE: date | None = None
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def normalize_login_username(username: str | None) -> str:
+    return (username or "").strip().lower()
+
+
+def password_policy_errors(password: str, username: str | None = None) -> list[str]:
+    if not current_app.config.get("AUTH_PASSWORD_POLICY_ENFORCE", True):
+        return []
+
+    errors: list[str] = []
+    value = password or ""
+    minimum_length = int(current_app.config.get("AUTH_PASSWORD_MIN_LENGTH", 12))
+
+    if len(value) < minimum_length:
+        errors.append(f"Password must be at least {minimum_length} characters.")
+
+    if not any(ch.islower() for ch in value):
+        errors.append("Password must include at least one lowercase letter.")
+
+    if not any(ch.isupper() for ch in value):
+        errors.append("Password must include at least one uppercase letter.")
+
+    if not any(ch.isdigit() for ch in value):
+        errors.append("Password must include at least one digit.")
+
+    if not any(not ch.isalnum() for ch in value):
+        errors.append("Password must include at least one symbol.")
+
+    normalized_username = normalize_login_username(username)
+    if normalized_username and normalized_username in value.lower():
+        errors.append("Password cannot contain your username.")
+
+    return errors
+
+
+def is_password_reused(user, new_password: str, history_count: int) -> bool:
+    if user.check_password(new_password):
+        return True
+
+    if history_count <= 0:
+        return False
+
+    history_rows = (
+        UserPasswordHistory.query.filter_by(user_id=user.id)
+        .order_by(UserPasswordHistory.created_at.desc(), UserPasswordHistory.id.desc())
+        .limit(history_count)
+        .all()
+    )
+    for row in history_rows:
+        if check_password_hash(row.password_hash, new_password):
+            return True
+    return False
+
+
+def store_password_history(user_id: int, previous_password_hash: str, history_count: int) -> None:
+    if not previous_password_hash:
+        return
+
+    db.session.add(
+        UserPasswordHistory(
+            user_id=user_id,
+            password_hash=previous_password_hash,
+            created_at=utc_now(),
+        )
+    )
+    db.session.flush()
+
+    if history_count <= 0:
+        UserPasswordHistory.query.filter_by(user_id=user_id).delete(synchronize_session=False)
+        return
+
+    keep_ids = (
+        db.session.query(UserPasswordHistory.id)
+        .filter(UserPasswordHistory.user_id == user_id)
+        .order_by(UserPasswordHistory.created_at.desc(), UserPasswordHistory.id.desc())
+        .limit(history_count)
+        .all()
+    )
+    keep_id_set = {row.id for row in keep_ids}
+    if not keep_id_set:
+        return
+
+    (
+        UserPasswordHistory.query.filter(UserPasswordHistory.user_id == user_id)
+        .filter(~UserPasswordHistory.id.in_(keep_id_set))
+        .delete(synchronize_session=False)
+    )
+
+
+def _load_attempt(client_ip: str, username: str) -> LoginAttempt | None:
+    return LoginAttempt.query.filter_by(client_ip=client_ip, username=username).first()
+
+
+def _remove_expired_attempt(record: LoginAttempt, now: datetime, window_seconds: int) -> bool:
+    if record.locked_until:
+        locked_until = record.locked_until.replace(tzinfo=timezone.utc)
+        if now >= locked_until:
+            db.session.delete(record)
+            return True
+        return False
+
+    first_attempt = record.first_attempt_at.replace(tzinfo=timezone.utc)
+    if (now - first_attempt).total_seconds() > window_seconds:
+        db.session.delete(record)
+        return True
+
+    return False
+
+
+def _attempt_window_seconds() -> int:
+    lockout_window = int(current_app.config.get("AUTH_LOCKOUT_WINDOW_SECONDS", 300))
+    legacy_window = int(current_app.config.get("AUTH_ATTEMPT_WINDOW_SECONDS", 300))
+    default_window = int(getattr(AppConfig, "AUTH_LOCKOUT_WINDOW_SECONDS", 300))
+    if (
+        "AUTH_LOCKOUT_WINDOW_SECONDS" in current_app.config
+        and lockout_window != default_window
+    ):
+        return lockout_window
+    return legacy_window
+
+
+def _lockout_seconds() -> int:
+    return int(current_app.config.get("AUTH_LOCKOUT_SECONDS", 600))
+
+
+def _legacy_limit_was_overridden(config_key: str) -> bool:
+    default_value = getattr(AppConfig, config_key, None)
+    current_value = current_app.config.get(config_key)
+    return (
+        current_value != default_value
+        or config_key in os.environ
+    )
+
+
+def _limit_for_scope(scope: str) -> int:
+    fallback_max = int(current_app.config.get("AUTH_LOCKOUT_MAX_ATTEMPTS", 5))
+    if scope == "ip_account":
+        if _legacy_limit_was_overridden("AUTH_MAX_ATTEMPTS_IP_ACCOUNT"):
+            return int(current_app.config.get("AUTH_MAX_ATTEMPTS_IP_ACCOUNT", fallback_max))
+        return fallback_max
+    if scope == "account":
+        if _legacy_limit_was_overridden("AUTH_MAX_ATTEMPTS_ACCOUNT"):
+            return int(current_app.config.get("AUTH_MAX_ATTEMPTS_ACCOUNT", fallback_max))
+        return fallback_max
+    if _legacy_limit_was_overridden("AUTH_MAX_ATTEMPTS_IP"):
+        return int(current_app.config.get("AUTH_MAX_ATTEMPTS_IP", fallback_max))
+    return fallback_max
+
+
+def check_login_limited(client_ip: str, username: str) -> tuple[bool, int | None, str | None]:
+    now = utc_now()
+    window_seconds = _attempt_window_seconds()
+    normalized_username = normalize_login_username(username)
+
+    ip_record = _load_attempt(client_ip, IP_SCOPE_USERNAME)
+    account_record = _load_attempt(ACCOUNT_SCOPE_IP, normalized_username)
+    ip_account_record = _load_attempt(client_ip, normalized_username) if normalized_username else None
+
+    mutated = False
+    for record in (ip_record, account_record, ip_account_record):
+        if record and _remove_expired_attempt(record, now, window_seconds):
+            mutated = True
+
+    if mutated:
+        db.session.commit()
+        ip_record = _load_attempt(client_ip, IP_SCOPE_USERNAME)
+        account_record = _load_attempt(ACCOUNT_SCOPE_IP, normalized_username)
+        ip_account_record = _load_attempt(client_ip, normalized_username) if normalized_username else None
+
+    limited_seconds: int | None = None
+    scope: str | None = None
+
+    if ip_record and ip_record.locked_until:
+        remaining = int((ip_record.locked_until.replace(tzinfo=timezone.utc) - now).total_seconds())
+        if remaining > 0:
+            limited_seconds = remaining
+            scope = "ip"
+
+    if account_record and account_record.locked_until:
+        remaining = int((account_record.locked_until.replace(tzinfo=timezone.utc) - now).total_seconds())
+        if remaining > 0 and (limited_seconds is None or remaining > limited_seconds):
+            limited_seconds = remaining
+            scope = "account"
+
+    if ip_account_record and ip_account_record.locked_until:
+        remaining = int((ip_account_record.locked_until.replace(tzinfo=timezone.utc) - now).total_seconds())
+        if remaining > 0 and (limited_seconds is None or remaining > limited_seconds):
+            limited_seconds = remaining
+            scope = "ip_account"
+
+    return limited_seconds is not None, limited_seconds, scope
+
+
+def _record_failed_attempt(scope_ip: str, scope_username: str, now: datetime, scope: str) -> bool:
+    max_attempts = _limit_for_scope(scope)
+    window_seconds = _attempt_window_seconds()
+    lockout_seconds = _lockout_seconds()
+
+    record = _load_attempt(scope_ip, scope_username)
+    if not record:
+        record = LoginAttempt(
+            client_ip=scope_ip,
+            username=scope_username,
+            attempt_count=1,
+            first_attempt_at=now,
+        )
+        if max_attempts <= 1:
+            record.locked_until = now + timedelta(seconds=lockout_seconds)
+            db.session.add(record)
+            return True
+        db.session.add(record)
+        return False
+
+    if _remove_expired_attempt(record, now, window_seconds):
+        record = LoginAttempt(
+            client_ip=scope_ip,
+            username=scope_username,
+            attempt_count=1,
+            first_attempt_at=now,
+        )
+        db.session.add(record)
+        return False
+
+    record.attempt_count += 1
+    just_locked = False
+    if record.attempt_count >= max_attempts:
+        locked_until = now + timedelta(seconds=lockout_seconds)
+        if not record.locked_until or record.locked_until.replace(tzinfo=timezone.utc) < now:
+            just_locked = True
+        record.locked_until = locked_until
+
+    return just_locked
+
+
+def record_failed_login(client_ip: str, username: str) -> dict[str, bool]:
+    now = utc_now()
+    normalized_username = normalize_login_username(username)
+    ip_locked_now = _record_failed_attempt(client_ip, IP_SCOPE_USERNAME, now, "ip")
+    account_locked_now = False
+    ip_account_locked_now = False
+    if normalized_username:
+        account_locked_now = _record_failed_attempt(ACCOUNT_SCOPE_IP, normalized_username, now, "account")
+        ip_account_locked_now = _record_failed_attempt(client_ip, normalized_username, now, "ip_account")
+
+    db.session.commit()
+    return {
+        "ip_locked_now": ip_locked_now,
+        "account_locked_now": account_locked_now,
+        "ip_account_locked_now": ip_account_locked_now,
+    }
+
+
+def clear_failed_logins(client_ip: str, username: str) -> None:
+    normalized_username = normalize_login_username(username)
+    LoginAttempt.query.filter_by(client_ip=client_ip, username=IP_SCOPE_USERNAME).delete()
+    if normalized_username:
+        LoginAttempt.query.filter_by(client_ip=ACCOUNT_SCOPE_IP, username=normalized_username).delete()
+        LoginAttempt.query.filter_by(client_ip=client_ip, username=normalized_username).delete()
+    db.session.commit()
+
+
+def prune_auth_events(retention_days: int) -> None:
+    if retention_days <= 0:
+        return
+
+    cutoff = utc_now() - timedelta(days=retention_days)
+    AuthEvent.query.filter(AuthEvent.created_at < cutoff).delete(synchronize_session=False)
+
+
+def maybe_prune_auth_events() -> None:
+    global _LAST_PRUNE_DATE
+
+    today = utc_now().date()
+    if _LAST_PRUNE_DATE == today:
+        return
+
+    retention_days = current_app.config.get("AUTH_EVENT_RETENTION_DAYS", 180)
+    prune_auth_events(retention_days)
+    _LAST_PRUNE_DATE = today
+
+
+def record_auth_event(
+    event_type: str,
+    *,
+    outcome: str = "success",
+    user=None,
+    username: str | None = None,
+    client_ip: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    try:
+        maybe_prune_auth_events()
+
+        event = AuthEvent(
+            event_type=event_type,
+            outcome=outcome,
+            user_id=(user.id if user else None),
+            username=(username or (user.username if user else None)),
+            client_ip=client_ip,
+            created_at=utc_now(),
+        )
+        event.set_metadata(metadata)
+        db.session.add(event)
+        db.session.commit()
+    except SQLAlchemyError:
+        db.session.rollback()
+        current_app.logger.exception("Failed to persist auth event: %s", event_type)

--- a/app/services/security_alert_service.py
+++ b/app/services/security_alert_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from flask import current_app
+
+from app.services.twilio_service import get_twilio_service
+from app.utils import normalize_phone, validate_phone
+
+
+_EVENT_LABELS = {
+    "password_changed": "Your password was changed.",
+    "admin_password_reset": "An administrator reset your password.",
+    "account_lockout": "Your account was temporarily locked after multiple failed sign-in attempts.",
+}
+
+
+def _format_alert_message(event_type: str, username: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    event_text = _EVENT_LABELS.get(event_type, "A security event occurred on your account.")
+    return (
+        f"AOC SMS security alert for {username}: {event_text} "
+        f"Time: {stamp}. If this was not expected, contact an administrator immediately."
+    )
+
+
+def send_security_alert(user, event_type: str) -> dict:
+    if not current_app.config.get("AUTH_ALERTS_ENABLED", True):
+        return {"success": False, "skipped": True, "reason": "alerts_disabled"}
+
+    if not user:
+        return {"success": False, "skipped": True, "reason": "no_user"}
+
+    phone = normalize_phone(user.phone or "")
+    if not validate_phone(phone):
+        return {"success": False, "skipped": True, "reason": "missing_or_invalid_phone"}
+
+    try:
+        service = get_twilio_service()
+        body = _format_alert_message(event_type, user.username)
+        result = service.send_message(phone, body)
+        if result.get("success"):
+            return {"success": True, "skipped": False, "reason": None}
+        return {
+            "success": False,
+            "skipped": False,
+            "reason": result.get("error") or "twilio_send_failed",
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "success": False,
+            "skipped": False,
+            "reason": str(exc),
+        }

--- a/app/templates/auth/security_contact.html
+++ b/app/templates/auth/security_contact.html
@@ -1,0 +1,46 @@
+{% extends "auth/base.html" %}
+
+{% block title %}Security Contact - SMS Admin{% endblock %}
+
+{% block page_title %}Security Contact{% endblock %}
+
+{% block breadcrumbs %}
+<span>Security Contact</span>
+{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6">
+        <div class="card app-card">
+            <div class="card-header">
+                <h5 class="mb-0">
+                    <i class="bi bi-shield-check me-2"></i>Set your security alert phone
+                </h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">Add a phone number to receive security alerts and continue using the app.</p>
+                <form method="POST">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="mb-4">
+                        <label for="phone" class="form-label">Phone number <span class="text-danger">*</span></label>
+                        <input
+                            type="tel"
+                            class="form-control"
+                            id="phone"
+                            name="phone"
+                            required
+                            autocomplete="tel"
+                            placeholder="+15551234567"
+                            value="{{ current_user.phone or '' }}"
+                        >
+                        <div class="form-text">Use E.164 format (for US numbers, start with +1).</div>
+                    </div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-lg me-1"></i>Save and continue
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,7 @@
     {% set logs_active = request.endpoint and request.endpoint.startswith('main.logs') %}
     {% set inbox_active = request.endpoint and request.endpoint.startswith('main.inbox') %}
     {% set automation_active = request.endpoint and (request.endpoint.startswith('main.keyword_rule') or request.endpoint.startswith('main.keyword_rules') or request.endpoint.startswith('main.survey_flow') or request.endpoint.startswith('main.survey_flows')) %}
+    {% set security_active = request.endpoint and request.endpoint.startswith('main.security_events') %}
     <div class="app-shell">
         <aside class="app-sidebar d-none d-lg-flex flex-column">
             <a class="app-sidebar-brand" href="{{ url_for('main.dashboard') }}">
@@ -62,6 +63,9 @@
                 <a class="app-nav-link {% if 'users' in request.endpoint %}active{% endif %}" href="{{ url_for('main.users_list') }}">
                     <i class="bi bi-person-gear me-2"></i>Users
                 </a>
+                <a class="app-nav-link {% if security_active %}active{% endif %}" href="{{ url_for('main.security_events') }}">
+                    <i class="bi bi-shield-lock me-2"></i>Security
+                </a>
                 {% endif %}
             </nav>
             {% if current_user.is_authenticated %}
@@ -69,9 +73,12 @@
                 <a class="app-nav-link" href="{{ url_for('main.change_password') }}">
                     <i class="bi bi-key me-2"></i>Change Password
                 </a>
-                <a class="app-nav-link" href="{{ url_for('auth.logout') }}">
-                    <i class="bi bi-box-arrow-right me-2"></i>Logout
-                </a>
+                <form method="POST" action="{{ url_for('auth.logout') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="app-nav-link btn btn-link p-0 text-start w-100">
+                        <i class="bi bi-box-arrow-right me-2"></i>Logout
+                    </button>
+                </form>
             </div>
             {% endif %}
         </aside>
@@ -129,14 +136,20 @@
                             <a class="app-nav-link {% if 'users' in request.endpoint %}active{% endif %}" href="{{ url_for('main.users_list') }}">
                                 <i class="bi bi-person-gear me-2"></i>Users
                             </a>
+                            <a class="app-nav-link {% if security_active %}active{% endif %}" href="{{ url_for('main.security_events') }}">
+                                <i class="bi bi-shield-lock me-2"></i>Security
+                            </a>
                             {% endif %}
                             {% if current_user.is_authenticated %}
                             <a class="app-nav-link mt-2" href="{{ url_for('main.change_password') }}">
                                 <i class="bi bi-key me-2"></i>Change Password
                             </a>
-                            <a class="app-nav-link mt-2" href="{{ url_for('auth.logout') }}">
-                                <i class="bi bi-box-arrow-right me-2"></i>Logout
-                            </a>
+                            <form method="POST" action="{{ url_for('auth.logout') }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="app-nav-link mt-2 btn btn-link p-0 text-start w-100">
+                                    <i class="bi bi-box-arrow-right me-2"></i>Logout
+                                </button>
+                            </form>
                             {% endif %}
                         </div>
                     </div>

--- a/app/templates/security/events.html
+++ b/app/templates/security/events.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block title %}Security Events - SMS Admin{% endblock %}
+{% block page_title %}Security Events{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ url_for('main.dashboard') }}">Dashboard</a> / <span>Security Events</span>
+{% endblock %}
+
+{% block content %}
+<div class="card app-card mb-3">
+    <div class="card-body">
+        <form method="GET" class="row g-3 align-items-end">
+            <div class="col-md-3">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" class="form-control" id="username" name="username" value="{{ filters.username }}">
+            </div>
+            <div class="col-md-2">
+                <label for="event_type" class="form-label">Event type</label>
+                <select class="form-select" id="event_type" name="event_type">
+                    <option value="">All</option>
+                    {% for value in event_type_options %}
+                    <option value="{{ value }}" {% if filters.event_type == value %}selected{% endif %}>{{ value }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label for="outcome" class="form-label">Outcome</label>
+                <select class="form-select" id="outcome" name="outcome">
+                    <option value="">All</option>
+                    {% for value in outcome_options %}
+                    <option value="{{ value }}" {% if filters.outcome == value %}selected{% endif %}>{{ value }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label for="date_from" class="form-label">From</label>
+                <input type="date" class="form-control" id="date_from" name="date_from" value="{{ filters.date_from }}">
+            </div>
+            <div class="col-md-2">
+                <label for="date_to" class="form-label">To</label>
+                <input type="date" class="form-control" id="date_to" name="date_to" value="{{ filters.date_to }}">
+            </div>
+            <div class="col-md-1 d-grid">
+                <button type="submit" class="btn btn-primary">Filter</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card app-card">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th>Time (UTC)</th>
+                    <th>Event</th>
+                    <th>Outcome</th>
+                    <th>User</th>
+                    <th>IP</th>
+                    <th>Metadata</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% if events %}
+                    {% for event in events %}
+                    <tr>
+                        <td>{{ event.created_at.strftime('%Y-%m-%d %H:%M:%S') if event.created_at else '-' }}</td>
+                        <td>{{ event.event_type }}</td>
+                        <td>
+                            <span class="badge bg-{{ 'success' if event.outcome == 'success' else ('warning text-dark' if event.outcome == 'blocked' else 'danger') }}">
+                                {{ event.outcome }}
+                            </span>
+                        </td>
+                        <td>{{ event.username or '-' }}</td>
+                        <td>{{ event.client_ip or '-' }}</td>
+                        <td>
+                            <code class="small">{{ event.metadata_json or '-' }}</code>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                {% else %}
+                    <tr>
+                        <td colspan="6" class="text-center text-muted py-4">No security events found.</td>
+                    </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/users/form.html
+++ b/app/templates/users/form.html
@@ -30,6 +30,14 @@
                     </div>
 
                     <div class="mb-3">
+                        <label for="phone" class="form-label">Phone <span class="text-danger">*</span></label>
+                        <input type="tel" class="form-control" id="phone" name="phone" required autocomplete="tel"
+                               value="{{ user.phone if user else '' }}"
+                               placeholder="+15551234567">
+                        <div class="form-text">Used for security alerts (password reset, lockout, password change).</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label for="role" class="form-label">Role <span class="text-danger">*</span></label>
                         <select class="form-select" id="role" name="role" required>
                             <option value="" disabled {% if not user %}selected{% endif %}>Select role</option>

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -32,6 +32,12 @@
                             <span class="sort-indicator" aria-hidden="true"></span>
                         </button>
                     </th>
+                    <th data-sort-type="string">
+                        <button type="button" class="sort-button" data-sort-key="phone">
+                            <span>Phone</span>
+                            <span class="sort-indicator" aria-hidden="true"></span>
+                        </button>
+                    </th>
                     <th data-sort-type="date">
                         <button type="button" class="sort-button" data-sort-key="created">
                             <span>Created</span>
@@ -55,6 +61,9 @@
                             <span class="badge bg-{{ 'primary' if user.is_admin else 'info' }}">
                                 {{ 'Admin' if user.is_admin else 'Social Media Manager' }}
                             </span>
+                        </td>
+                        <td data-sort-value="{{ user.phone or '' }}">
+                            {{ user.phone or '-' }}
                         </td>
                         <td data-sort-value="{{ user.created_at.isoformat() if user.created_at else '' }}">
                             {{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '-' }}
@@ -81,7 +90,7 @@
                     {% endfor %}
                 {% else %}
                     <tr>
-                        <td colspan="4" class="text-center text-muted py-4">
+                        <td colspan="5" class="text-center text-muted py-4">
                             No users found.
                         </td>
                     </tr>
@@ -105,6 +114,7 @@
                             {% endif %}
                         </div>
                         <div class="text-muted small mt-2">Created {{ user.created_at.strftime('%Y-%m-%d') if user.created_at else '-' }}</div>
+                        <div class="text-muted small mt-1">Phone {{ user.phone or '-' }}</div>
                     </div>
                 </div>
                 <div class="d-flex flex-wrap gap-2 mt-3 row-actions">

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,7 @@ This document describes all HTTP routes in the SMS Admin application.
 ## Authentication
 
 All routes except `/health`, `/login`, and `/webhooks/twilio/inbound` require authentication via Flask-Login session.
+Authenticated users without a security phone are redirected to `/account/security-contact` until configured.
 
 ### Login Flow
 
@@ -17,7 +18,16 @@ username=admin&password=secret&remember=on
 
 **Rate Limiting:**
 - 5 failed attempts within 5 minutes triggers 10-minute lockout
-- Tracked per client IP in database
+- Tracked per client IP and account in database
+
+### Logout Flow
+
+```
+POST /logout
+Content-Type: application/x-www-form-urlencoded
+
+csrf_token=...
+```
 
 ## Public Routes
 
@@ -122,6 +132,25 @@ POST /account/password
 Content-Type: application/x-www-form-urlencoded
 
 current_password=old&new_password=new&confirm_password=new
+```
+
+Successful password change invalidates active sessions and redirects to `/login`.
+
+### Security Contact
+
+```
+GET /account/security-contact
+POST /account/security-contact
+Content-Type: application/x-www-form-urlencoded
+
+phone=+15551234567
+```
+
+### Security Events (Admin Only)
+
+```
+GET /security/events
+GET /security/events?username=admin&event_type=password_changed&outcome=success&date_from=2026-02-01&date_to=2026-02-21
 ```
 
 ---

--- a/docs/auth-hardening-phases.md
+++ b/docs/auth-hardening-phases.md
@@ -1,0 +1,232 @@
+# Auth Hardening Phases (Codex-Owned)
+
+Status legend:
+- `[ ]` Not Started
+- `[~]` In Progress
+- `[x]` Done
+- `[!]` Blocked
+
+Rules:
+- Owner for all tasks: Codex
+- Only Codex updates status/evidence in this file.
+- A task is `[x]` only after implementation + verification evidence is recorded.
+
+## Phase 0 — Tracking + Baseline
+
+### PH0-01 Create tracker file
+- Status: `[x]`
+- Owner: Codex
+- Files: `docs/auth-hardening-phases.md`
+- DoD: Tracking file exists with all phase tasks and status protocol.
+- Evidence: Created file at 2026-02-21.
+
+### PH0-02 Confirm Python 3.11 runtime for tests
+- Status: `[x]`
+- Owner: Codex
+- Files: N/A
+- DoD: Confirm python3.11 execution path and record result.
+- Evidence: `python3.11 --version` -> `Python 3.11.14` on 2026-02-21.
+
+### PH0-03 Record baseline auth behavior
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/auth.py`, `app/routes.py`
+- DoD: Baseline behavior recorded (GET logout, password change does not force logout).
+- Evidence:
+  - `/logout` route is `GET` in `app/auth.py`.
+  - `/account/password` success path redirects to dashboard in `app/routes.py` without forced logout.
+
+## Phase 1 — Core Auth Hardening
+
+### PH1-01 Migration 010 (auth hardening tables/columns)
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/migrations/010_add_auth_hardening_tables_and_columns.py`
+- DoD: Adds users.phone, users.session_nonce, login_attempts.username, password history and auth events tables/indexes.
+- Evidence:
+  - Added `app/migrations/010_add_auth_hardening_tables_and_columns.py`.
+  - Validated via `./venv/bin/python -m pytest -q tests/test_migrations.py tests/test_dbdoctor.py` -> pass.
+
+### PH1-02 Model updates for new auth types
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/models.py`
+- DoD: AppUser supports nonce-bound session IDs; new models exist.
+- Evidence:
+  - Updated `app/models.py` with `AppUser.phone`, `AppUser.session_nonce`, nonce-bound `get_id()`, `UserPasswordHistory`, `AuthEvent`, `LoginAttempt.username`.
+
+### PH1-03 Auth security service
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/services/auth_security_service.py`
+- DoD: Password policy/history and auth event helpers implemented.
+- Evidence:
+  - Added `app/services/auth_security_service.py` with lockout helpers, password policy/reuse logic, event recording, and retention prune.
+
+### PH1-04 Login hardening
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/auth.py`
+- DoD: Username-aware lockout + session-fixation mitigation on login.
+- Evidence:
+  - Updated `app/auth.py` login flow with account+IP lockout checks, fixation mitigation (`session.clear()` before `login_user`), and audit events.
+
+### PH1-05 POST-only logout
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/auth.py`, `app/templates/base.html`
+- DoD: Logout endpoint is POST and UI uses CSRF-protected form submit.
+- Evidence:
+  - `app/auth.py` logout route changed to `POST`.
+  - Verified by `./venv/bin/python -m pytest -q tests/test_auth_hardening.py` (`test_logout_requires_post`) -> pass.
+
+### PH1-06 Password change hardening
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/routes.py`
+- DoD: Complexity/reuse checks and forced re-login after password update.
+- Evidence:
+  - Updated `app/routes.py` change password flow with complexity/reuse checks, nonce rotation, password history write, logout + re-login requirement.
+  - Verified by `./venv/bin/python -m pytest -q tests/test_password_change.py tests/test_auth_hardening.py` -> pass.
+
+### PH1-07 Navigation logout migration
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/templates/base.html`
+- DoD: Desktop/mobile logout links converted to POST forms.
+- Evidence:
+  - Converted desktop/mobile logout links in `app/templates/base.html` to CSRF-protected POST forms.
+
+## Phase 2 — Phone Gate + Alerting + Admin Reset
+
+### PH2-01 Add security-contact route
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/routes.py`
+- DoD: GET/POST `/account/security-contact` implemented.
+- Evidence:
+  - Implemented `GET/POST /account/security-contact` in `app/routes.py`.
+
+### PH2-02 Add security-contact template
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/templates/auth/security_contact.html`
+- DoD: Mandatory phone setup UI implemented.
+- Evidence:
+  - Added `app/templates/auth/security_contact.html`.
+
+### PH2-03 Missing-phone access gate
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/auth.py`
+- DoD: Authenticated users without phone are redirected to security-contact page.
+- Evidence:
+  - Added authenticated missing-phone gate in `app/auth.py`.
+  - Verified by `./venv/bin/python -m pytest -q tests/test_auth_hardening.py` (`test_missing_phone_is_redirected_to_security_contact`) -> pass.
+
+### PH2-04 Users CRUD requires phone
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/routes.py`, `app/templates/users/form.html`, `app/templates/users/list.html`
+- DoD: User create/edit validates and persists phone.
+- Evidence:
+  - Added phone validation and uniqueness checks in `app/routes.py` user add/edit.
+  - Updated `app/templates/users/form.html` and `app/templates/users/list.html` to include phone.
+  - Updated `tests/test_user_creation.py` for required phone + stronger password policy.
+
+### PH2-05 Security alert service
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/services/security_alert_service.py`
+- DoD: SMS alerts for password change/admin reset/lockout events.
+- Evidence:
+  - Added `app/services/security_alert_service.py` with per-user SMS alert delivery helpers.
+
+### PH2-06 Admin reset semantics
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/routes.py`
+- DoD: Admin password reset revokes sessions + forces password change.
+- Evidence:
+  - In `app/routes.py` admin password reset now rotates nonce, forces `must_change_password=True`, stores password history, writes auth event, and sends alert.
+
+### PH2-07 Non-blocking alert failures
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/services/security_alert_service.py`, `app/routes.py`, `app/auth.py`
+- DoD: Auth actions proceed when alert SMS fails; failure is audited.
+- Evidence:
+  - `app/auth.py` and `app/routes.py` record `alert_sms_failed` audit events on alert send failure without blocking auth/password flows.
+
+## Phase 3 — Security Event Visibility + Retention
+
+### PH3-01 Add security events route
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/routes.py`
+- DoD: Admin-only security event page route with filters.
+- Evidence:
+  - Added admin-only `/security/events` in `app/routes.py`.
+
+### PH3-02 Add security events template
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/templates/security/events.html`
+- DoD: Render audit event list and filter UI.
+- Evidence:
+  - Added `app/templates/security/events.html` with filter UI and results table.
+
+### PH3-03 Event retention pruning
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/services/auth_security_service.py`
+- DoD: Retain auth events for 180 days.
+- Evidence:
+  - Implemented prune-once-per-day behavior in `app/services/auth_security_service.py` using `AUTH_EVENT_RETENTION_DAYS`.
+
+### PH3-04 Add nav access for admins
+- Status: `[x]`
+- Owner: Codex
+- Files: `app/templates/base.html`
+- DoD: Admin nav includes security events page.
+- Evidence:
+  - Added admin security nav entries in `app/templates/base.html` (desktop + mobile).
+
+## Phase 4 — Tests + Docs + Final Verification
+
+### PH4-01 Tests
+- Status: `[x]`
+- Owner: Codex
+- Files: `tests/*`
+- DoD: Existing + new auth tests pass in supported runtime.
+- Evidence:
+  - Added explicit Phase 4 files:
+    - `tests/test_password_policy.py`
+    - `tests/test_auth_session_invalidation.py`
+    - `tests/test_login_lockout.py`
+    - `tests/test_security_contact_gate.py`
+    - `tests/test_security_events_routes.py`
+  - `./venv/bin/python -m pytest -q tests/test_password_policy.py tests/test_auth_session_invalidation.py tests/test_login_lockout.py tests/test_security_contact_gate.py tests/test_security_events_routes.py` -> `12 passed`.
+  - `./venv/bin/python -m pytest -q tests/test_auth_hardening.py tests/test_password_change.py tests/test_user_creation.py tests/test_inbox_routes.py tests/test_events_routes.py tests/test_scheduled_routes.py tests/test_community_search_sidebar.py tests/test_export_csv_security.py tests/test_inbox_keyword_conflicts.py tests/test_keyword_conflicts.py tests/test_inbox_automation_routes.py tests/test_migrations.py tests/test_dbdoctor.py` -> `82 passed`.
+  - `./venv/bin/python -m pytest -q tests/test_auth_hardening.py tests/test_password_change.py tests/test_user_creation.py` -> `9 passed`.
+  - `./venv/bin/python -m pytest -q tests/test_inbox_routes.py tests/test_events_routes.py tests/test_scheduled_routes.py tests/test_community_search_sidebar.py tests/test_export_csv_security.py tests/test_inbox_keyword_conflicts.py tests/test_keyword_conflicts.py tests/test_inbox_automation_routes.py` -> `67 passed`.
+  - `./venv/bin/python -m pytest -q tests/test_migrations.py tests/test_dbdoctor.py` -> `6 passed`.
+  - `./venv/bin/python -m pytest -q` -> `163 passed`.
+
+### PH4-02 Docs and config samples
+- Status: `[x]`
+- Owner: Codex
+- Files: `docs/api.md`, `docs/database.md`, `docs/configuration.md`, `docs/troubleshooting.md`, `.env.example`, `README.md`
+- DoD: Docs reflect new routes, auth behavior, env vars.
+- Evidence:
+  - Updated `.env.example`, `docs/api.md`, `docs/configuration.md`, `docs/database.md`, `docs/troubleshooting.md`, and `README.md`.
+
+### PH4-03 Final verification and phase closure
+- Status: `[x]`
+- Owner: Codex
+- Files: `docs/auth-hardening-phases.md`
+- DoD: Completed phase statuses + verification commands recorded.
+- Evidence:
+  - Completed phase statuses and evidence in this file.
+  - Added `pytest.ini` with `testpaths = tests` to scope suite collection to this repo's tests and avoid nested `AOC-SMS-Admin/tests` collisions.
+  - Full-suite verification now passes in Python 3.11: `./venv/bin/python -m pytest -q` -> `163 passed`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,18 @@ If `DATABASE_URL` is unset, the app defaults to `instance/sms.db` under the proj
 |----------|---------|-------------|
 | `SESSION_COOKIE_SAMESITE` | `Lax` | Cookie SameSite policy |
 | `SESSION_COOKIE_SECURE` | `1` (prod), `0` (dev) | Require HTTPS for cookies |
+| `REMEMBER_COOKIE_DURATION_DAYS` | `7` | Remember-me session lifetime |
+
+### Auth Hardening
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PASSWORD_HISTORY_COUNT` | `3` | Number of prior passwords blocked for reuse |
+| `AUTH_ALERTS_ENABLED` | `1` | Enable SMS security alerts |
+| `AUTH_EVENT_RETENTION_DAYS` | `180` | Auth event retention window |
+| `AUTH_LOCKOUT_MAX_ATTEMPTS` | `5` | Failed login attempts before lockout |
+| `AUTH_LOCKOUT_WINDOW_SECONDS` | `300` | Failure counting window |
+| `AUTH_LOCKOUT_SECONDS` | `600` | Lockout duration |
 
 ### Login Hardening (Recommended for Production)
 
@@ -137,6 +149,11 @@ class Config:
     AUTH_PASSWORD_MIN_LENGTH = int(os.environ.get('AUTH_PASSWORD_MIN_LENGTH', '12'))
     AUTH_PASSWORD_POLICY_ENFORCE = os.environ.get('AUTH_PASSWORD_POLICY_ENFORCE', '1') == '1'
     TRUSTED_HOSTS = [h.strip() for h in os.environ.get('TRUSTED_HOSTS', '').split(',') if h.strip()]
+    PASSWORD_HISTORY_COUNT = int(os.environ.get('PASSWORD_HISTORY_COUNT', '3'))
+    AUTH_ALERTS_ENABLED = os.environ.get('AUTH_ALERTS_ENABLED', '1') == '1'
+    AUTH_EVENT_RETENTION_DAYS = int(os.environ.get('AUTH_EVENT_RETENTION_DAYS', '180'))
+    AUTH_LOCKOUT_MAX_ATTEMPTS = int(os.environ.get('AUTH_LOCKOUT_MAX_ATTEMPTS', '5'))
+    AUTH_LOCKOUT_WINDOW_SECONDS = int(os.environ.get('AUTH_LOCKOUT_WINDOW_SECONDS', '300'))
 
     # Scheduler
     SCHEDULER_ENABLED = os.environ.get('SCHEDULER_ENABLED', '1' if DEBUG else '0') == '1'

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -169,6 +169,11 @@ TWILIO_FROM_NUMBER=+1xxxx
 sqlite3 /opt/sms-admin/instance/sms.db "DELETE FROM login_attempts WHERE client_ip='x.x.x.x';"
 ```
 
+If account-scoped lockouts are enabled, also clear username-scoped entries:
+```bash
+sqlite3 /opt/sms-admin/instance/sms.db "DELETE FROM login_attempts WHERE client_ip='__account__' AND username='admin';"
+```
+
 ### Forgot Password
 
 **Solution:** Reset via database:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/tests/test_auth_hardening.py
+++ b/tests/test_auth_hardening.py
@@ -1,0 +1,134 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestAuthHardening(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser
+
+        self.db = db
+        self.AppUser = AppUser
+
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+            AUTH_LOCKOUT_MAX_ATTEMPTS=3,
+            AUTH_LOCKOUT_WINDOW_SECONDS=300,
+            AUTH_LOCKOUT_SECONDS=600,
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(username="admin", phone="+15550001001", role="admin", must_change_password=False)
+        admin.set_password("admin-pass")
+        viewer = self.AppUser(username="viewer", phone="+15550001002", role="viewer", must_change_password=False)
+        viewer.set_password("viewer-pass")
+        no_phone = self.AppUser(username="no-phone", phone=None, role="admin", must_change_password=False)
+        no_phone.set_password("no-phone-pass")
+
+        self.db.session.add_all([admin, viewer, no_phone])
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self, username: str, password: str):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=False,
+        )
+
+    def test_logout_requires_post(self) -> None:
+        self._login("admin", "admin-pass")
+
+        response = self.client.get("/logout", follow_redirects=False)
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.post("/logout", follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.headers.get("Location", ""))
+
+    def test_missing_phone_is_redirected_to_security_contact(self) -> None:
+        self._login("no-phone", "no-phone-pass")
+
+        response = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/account/security-contact", response.headers.get("Location", ""))
+
+        save_response = self.client.post(
+            "/account/security-contact",
+            data={"phone": "+15550001003"},
+            follow_redirects=False,
+        )
+        self.assertEqual(save_response.status_code, 302)
+
+        dashboard = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(dashboard.status_code, 200)
+
+    def test_password_change_rotates_session_and_requires_relogin(self) -> None:
+        self._login("admin", "admin-pass")
+
+        user = self.AppUser.query.filter_by(username="admin").first()
+        self.assertIsNotNone(user)
+        old_nonce = user.session_nonce
+
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "admin-pass",
+                "new_password": "New-secure1!",
+                "confirm_password": "New-secure1!",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.headers.get("Location", ""))
+
+        self.db.session.refresh(user)
+        self.assertNotEqual(user.session_nonce, old_nonce)
+
+        dashboard = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(dashboard.status_code, 302)
+        self.assertIn("/login", dashboard.headers.get("Location", ""))
+
+        relogin = self._login("admin", "New-secure1!")
+        self.assertEqual(relogin.status_code, 302)
+
+    def test_security_events_admin_only(self) -> None:
+        self._login("admin", "admin-pass")
+        response = self.client.get("/security/events")
+        self.assertEqual(response.status_code, 200)
+
+        self.client.post("/logout", follow_redirects=False)
+        self._login("viewer", "viewer-pass")
+        forbidden = self.client.get("/security/events")
+        self.assertEqual(forbidden.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auth_session_invalidation.py
+++ b/tests/test_auth_session_invalidation.py
@@ -1,0 +1,153 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestAuthSessionInvalidation(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, AuthEvent
+
+        self.db = db
+        self.AppUser = AppUser
+        self.AuthEvent = AuthEvent
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550003001",
+            role="admin",
+            must_change_password=False,
+        )
+        admin.set_password("Admin-pass1!")
+        target = self.AppUser(
+            username="target",
+            phone="+15550003002",
+            role="social_manager",
+            must_change_password=False,
+        )
+        target.set_password("Target-pass1!")
+        self.db.session.add_all([admin, target])
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login_admin(self, password: str = "Admin-pass1!"):
+        return self.client.post(
+            "/login",
+            data={"username": "admin", "password": password},
+            follow_redirects=False,
+        )
+
+    def _login_target(self, password: str):
+        return self.client.post(
+            "/login",
+            data={"username": "target", "password": password},
+            follow_redirects=False,
+        )
+
+    def test_password_change_invalidates_current_session(self) -> None:
+        self._login_target("Target-pass1!")
+        user = self.AppUser.query.filter_by(username="target").first()
+        self.assertIsNotNone(user)
+        old_nonce = user.session_nonce
+
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "Target-pass1!",
+                "new_password": "Fresh-Newpass1!",
+                "confirm_password": "Fresh-Newpass1!",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.headers.get("Location", ""))
+
+        self.db.session.refresh(user)
+        self.assertNotEqual(old_nonce, user.session_nonce)
+
+        dashboard = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(dashboard.status_code, 302)
+        self.assertIn("/login", dashboard.headers.get("Location", ""))
+
+        old_login = self._login_target("Target-pass1!")
+        self.assertEqual(old_login.status_code, 200)
+        self.assertIn(b"Invalid username or password.", old_login.data)
+
+        new_login = self._login_target("Fresh-Newpass1!")
+        self.assertEqual(new_login.status_code, 302)
+        self.assertIn("/dashboard", new_login.headers.get("Location", ""))
+
+    def test_admin_reset_revokes_target_sessions_and_forces_password_change(self) -> None:
+        from app.auth import load_user
+
+        self._login_admin()
+
+        target = self.AppUser.query.filter_by(username="target").first()
+        self.assertIsNotNone(target)
+        old_nonce = target.session_nonce
+        stale_session_id = target.get_id()
+
+        response = self.client.post(
+            f"/users/{target.id}/edit",
+            data={
+                "username": "target",
+                "role": "social_manager",
+                "phone": "+15550003002",
+                "password": "Admin-Reset1!",
+            },
+            follow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/users", response.headers.get("Location", ""))
+
+        self.db.session.refresh(target)
+        self.assertTrue(target.must_change_password)
+        self.assertNotEqual(old_nonce, target.session_nonce)
+
+        stale_user = load_user(stale_session_id)
+        self.assertIsNone(stale_user)
+
+        self.client.post("/logout", follow_redirects=False)
+
+        relogin = self._login_target("Admin-Reset1!")
+        self.assertEqual(relogin.status_code, 302)
+        self.assertIn("/account/password", relogin.headers.get("Location", ""))
+
+        reset_event = (
+            self.AuthEvent.query.filter_by(event_type="admin_password_reset", username="target")
+            .order_by(self.AuthEvent.id.desc())
+            .first()
+        )
+        self.assertIsNotNone(reset_event)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_community_search_sidebar.py
+++ b/tests/test_community_search_sidebar.py
@@ -32,7 +32,12 @@ class TestCommunitySearchSidebar(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000001",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.add(self.CommunityMember(name="Mariam Avetisyan", phone="+17202345027"))

--- a/tests/test_events_routes.py
+++ b/tests/test_events_routes.py
@@ -35,7 +35,12 @@ class TestEventsRoutes(unittest.TestCase):
 
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000002",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.commit()
@@ -117,7 +122,12 @@ class TestEventsRoutes(unittest.TestCase):
         self.assertIn(b'/events/bulk-delete', response.data)
 
     def test_events_list_hides_bulk_delete_controls_for_social_manager(self) -> None:
-        manager = self.AppUser(username="manager", role="social_manager", must_change_password=False)
+        manager = self.AppUser(
+            username="manager",
+            phone="+15550000003",
+            role="social_manager",
+            must_change_password=False,
+        )
         manager.set_password("manager-pass")
         self.db.session.add(manager)
         self.db.session.add(self.Event(title="Neighborhood Cleanup"))

--- a/tests/test_export_csv_security.py
+++ b/tests/test_export_csv_security.py
@@ -37,7 +37,12 @@ class TestCsvExportSecurity(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000006",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.commit()

--- a/tests/test_inbox_automation_routes.py
+++ b/tests/test_inbox_automation_routes.py
@@ -48,9 +48,19 @@ class TestInboxAutomationRouteValidation(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000010",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
-        viewer = self.AppUser(username="viewer", role="viewer", must_change_password=False)
+        viewer = self.AppUser(
+            username="viewer",
+            phone="+15550000011",
+            role="viewer",
+            must_change_password=False,
+        )
         viewer.set_password("viewer-pass")
         self.db.session.add_all([admin, viewer])
         self.db.session.commit()

--- a/tests/test_inbox_keyword_conflicts.py
+++ b/tests/test_inbox_keyword_conflicts.py
@@ -33,7 +33,12 @@ class TestInboxKeywordConflicts(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000007",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.commit()

--- a/tests/test_inbox_routes.py
+++ b/tests/test_inbox_routes.py
@@ -48,11 +48,26 @@ class TestInboxRoutes(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000012",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
-        social_manager = self.AppUser(username="social", role="social_manager", must_change_password=False)
+        social_manager = self.AppUser(
+            username="social",
+            phone="+15550000013",
+            role="social_manager",
+            must_change_password=False,
+        )
         social_manager.set_password("social-pass")
-        viewer = self.AppUser(username="viewer", role="viewer", must_change_password=False)
+        viewer = self.AppUser(
+            username="viewer",
+            phone="+15550000014",
+            role="viewer",
+            must_change_password=False,
+        )
         viewer.set_password("viewer-pass")
         self.db.session.add_all([admin, social_manager, viewer])
         self.db.session.commit()
@@ -82,7 +97,7 @@ class TestInboxRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
 
     def _logout(self) -> None:
-        response = self.client.get("/logout", follow_redirects=False)
+        response = self.client.post("/logout", follow_redirects=False)
         self.assertEqual(response.status_code, 302)
 
     def _create_thread(self, *, phone: str, contact_name: str | None = None):

--- a/tests/test_keyword_conflicts.py
+++ b/tests/test_keyword_conflicts.py
@@ -32,7 +32,12 @@ class TestKeywordCrossTableConflicts(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        user = self.AppUser(username="admin", role="admin", must_change_password=False)
+        user = self.AppUser(
+            username="admin",
+            phone="+15550000004",
+            role="admin",
+            must_change_password=False,
+        )
         user.set_password("admin-password")
         self.db.session.add(user)
         self.db.session.commit()

--- a/tests/test_login_lockout.py
+++ b/tests/test_login_lockout.py
@@ -1,0 +1,105 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestLoginLockout(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, AuthEvent, LoginAttempt
+
+        self.db = db
+        self.AppUser = AppUser
+        self.AuthEvent = AuthEvent
+        self.LoginAttempt = LoginAttempt
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(
+            TESTING=True,
+            WTF_CSRF_ENABLED=False,
+            AUTH_LOCKOUT_MAX_ATTEMPTS=3,
+            AUTH_LOCKOUT_WINDOW_SECONDS=300,
+            AUTH_LOCKOUT_SECONDS=600,
+        )
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        user = self.AppUser(
+            username="lockuser",
+            phone="+15550004001",
+            role="admin",
+            must_change_password=False,
+        )
+        user.set_password("Lock-user1!")
+        self.db.session.add(user)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _post_login(self, username: str, password: str, ip_address: str):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            environ_overrides={"REMOTE_ADDR": ip_address},
+            follow_redirects=True,
+        )
+
+    def test_lockout_applies_to_username_scope_and_records_audit_events(self) -> None:
+        for _ in range(3):
+            failed = self._post_login("lockuser", "wrong-password", "10.1.1.1")
+            self.assertEqual(failed.status_code, 200)
+            self.assertIn(b"Invalid username or password.", failed.data)
+
+        blocked = self._post_login("lockuser", "Lock-user1!", "10.1.1.2")
+        self.assertEqual(blocked.status_code, 200)
+        self.assertIn(b"Too many failed attempts.", blocked.data)
+
+        ip_scope_record = self.LoginAttempt.query.filter_by(client_ip="10.1.1.1", username="").first()
+        account_scope_record = self.LoginAttempt.query.filter_by(
+            client_ip="__account__",
+            username="lockuser",
+        ).first()
+        self.assertIsNotNone(ip_scope_record)
+        self.assertIsNotNone(account_scope_record)
+        self.assertIsNotNone(account_scope_record.locked_until)
+
+        blocked_event = (
+            self.AuthEvent.query.filter_by(event_type="login_blocked", username="lockuser")
+            .order_by(self.AuthEvent.id.desc())
+            .first()
+        )
+        self.assertIsNotNone(blocked_event)
+        self.assertEqual(blocked_event.metadata_payload.get("scope"), "account")
+
+        alert_failure_event = (
+            self.AuthEvent.query.filter_by(event_type="alert_sms_failed", username="lockuser")
+            .order_by(self.AuthEvent.id.desc())
+            .first()
+        )
+        self.assertIsNotNone(alert_failure_event)
+        self.assertEqual(alert_failure_event.metadata_payload.get("context"), "account_lockout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -31,7 +31,12 @@ class TestPasswordChangeFlow(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        user = self.AppUser(username="forced", role="admin", must_change_password=True)
+        user = self.AppUser(
+            username="forced",
+            phone="+15550000005",
+            role="admin",
+            must_change_password=True,
+        )
         user.set_password("old-password")
         self.db.session.add(user)
         self.db.session.commit()
@@ -74,20 +79,21 @@ class TestPasswordChangeFlow(unittest.TestCase):
             "/account/password",
             data={
                 "current_password": "old-password",
-                "new_password": "new-password",
-                "confirm_password": "new-password",
+                "new_password": "New-password1!",
+                "confirm_password": "New-password1!",
             },
             follow_redirects=False,
         )
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/dashboard", response.headers.get("Location", ""))
+        self.assertIn("/login", response.headers.get("Location", ""))
 
         user = self.AppUser.query.filter_by(username="forced").first()
         self.assertIsNotNone(user)
         self.assertFalse(user.must_change_password)
 
-        dashboard = self.client.get("/dashboard")
-        self.assertEqual(dashboard.status_code, 200)
+        dashboard = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(dashboard.status_code, 302)
+        self.assertIn("/login", dashboard.headers.get("Location", ""))
 
     def test_incorrect_current_password_is_rejected(self) -> None:
         self._login("old-password")
@@ -95,8 +101,8 @@ class TestPasswordChangeFlow(unittest.TestCase):
             "/account/password",
             data={
                 "current_password": "wrong-password",
-                "new_password": "new-password",
-                "confirm_password": "new-password",
+                "new_password": "New-password1!",
+                "confirm_password": "New-password1!",
             },
             follow_redirects=True,
         )
@@ -127,8 +133,8 @@ class TestPasswordChangeFlow(unittest.TestCase):
             "/account/password",
             data={
                 "current_password": "old-password",
-                "new_password": "new-password-123",
-                "confirm_password": "new-password-123",
+                "new_password": "New-password123!",
+                "confirm_password": "New-password123!",
             },
             follow_redirects=False,
         )
@@ -160,8 +166,8 @@ class TestPasswordChangeFlow(unittest.TestCase):
             "/account/password",
             data={
                 "current_password": "old-password",
-                "new_password": "new-password-123",
-                "confirm_password": "new-password-123",
+                "new_password": "New-password123!",
+                "confirm_password": "New-password123!",
             },
             follow_redirects=False,
         )

--- a/tests/test_password_policy.py
+++ b/tests/test_password_policy.py
@@ -1,0 +1,136 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+from werkzeug.security import generate_password_hash
+
+
+class TestPasswordPolicy(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, UserPasswordHistory
+
+        self.db = db
+        self.AppUser = AppUser
+        self.UserPasswordHistory = UserPasswordHistory
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, PASSWORD_HISTORY_COUNT=3)
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        user = self.AppUser(
+            username="policy-admin",
+            phone="+15550002001",
+            role="admin",
+            must_change_password=False,
+        )
+        user.set_password("Current-pass1!")
+        self.db.session.add(user)
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self) -> None:
+        return self.client.post(
+            "/login",
+            data={"username": "policy-admin", "password": "Current-pass1!"},
+            follow_redirects=False,
+        )
+
+    def test_change_password_rejects_weak_password(self) -> None:
+        self._login()
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "Current-pass1!",
+                "new_password": "short",
+                "confirm_password": "short",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Password must be at least 12 characters.", response.data)
+
+    def test_change_password_rejects_username_in_password(self) -> None:
+        self._login()
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "Current-pass1!",
+                "new_password": "Policy-Admin-456!",
+                "confirm_password": "Policy-Admin-456!",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Password cannot contain your username.", response.data)
+
+    def test_change_password_rejects_current_password_reuse(self) -> None:
+        self._login()
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "Current-pass1!",
+                "new_password": "Current-pass1!",
+                "confirm_password": "Current-pass1!",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"New password cannot match your current or recently used passwords.",
+            response.data,
+        )
+
+    def test_change_password_rejects_recent_password_reuse(self) -> None:
+        user = self.AppUser.query.filter_by(username="policy-admin").first()
+        self.assertIsNotNone(user)
+        self.db.session.add(
+            self.UserPasswordHistory(
+                user_id=user.id,
+                password_hash=generate_password_hash("Older-pass1!"),
+            )
+        )
+        self.db.session.commit()
+
+        self._login()
+        response = self.client.post(
+            "/account/password",
+            data={
+                "current_password": "Current-pass1!",
+                "new_password": "Older-pass1!",
+                "confirm_password": "Older-pass1!",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"New password cannot match your current or recently used passwords.",
+            response.data,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduled_routes.py
+++ b/tests/test_scheduled_routes.py
@@ -34,7 +34,12 @@ class TestScheduledStatusFiltering(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000008",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.commit()

--- a/tests/test_security_contact_gate.py
+++ b/tests/test_security_contact_gate.py
@@ -1,0 +1,112 @@
+import importlib
+import os
+import tempfile
+import unittest
+
+
+class TestSecurityContactGate(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser
+
+        self.db = db
+        self.AppUser = AppUser
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        no_phone = self.AppUser(
+            username="no-phone",
+            phone=None,
+            role="admin",
+            must_change_password=False,
+        )
+        no_phone.set_password("No-phone1!")
+        other_user = self.AppUser(
+            username="other-user",
+            phone="+15550005099",
+            role="social_manager",
+            must_change_password=False,
+        )
+        other_user.set_password("Other-user1!")
+        self.db.session.add_all([no_phone, other_user])
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login_no_phone_user(self):
+        return self.client.post(
+            "/login",
+            data={"username": "no-phone", "password": "No-phone1!"},
+            follow_redirects=False,
+        )
+
+    def test_missing_phone_user_is_blocked_until_security_contact_is_saved(self) -> None:
+        self._login_no_phone_user()
+
+        blocked_route = self.client.get("/users", follow_redirects=False)
+        self.assertEqual(blocked_route.status_code, 302)
+        self.assertIn("/account/security-contact", blocked_route.headers.get("Location", ""))
+
+        invalid = self.client.post(
+            "/account/security-contact",
+            data={"phone": "123"},
+            follow_redirects=True,
+        )
+        self.assertEqual(invalid.status_code, 200)
+        self.assertIn(b"Phone number must be a valid E.164 number.", invalid.data)
+
+        still_blocked = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(still_blocked.status_code, 302)
+        self.assertIn("/account/security-contact", still_blocked.headers.get("Location", ""))
+
+        saved = self.client.post(
+            "/account/security-contact",
+            data={"phone": "+15550005001"},
+            follow_redirects=False,
+        )
+        self.assertEqual(saved.status_code, 302)
+
+        dashboard = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(dashboard.status_code, 200)
+
+    def test_security_contact_rejects_duplicate_phone(self) -> None:
+        self._login_no_phone_user()
+
+        duplicate = self.client.post(
+            "/account/security-contact",
+            data={"phone": "+15550005099"},
+            follow_redirects=True,
+        )
+        self.assertEqual(duplicate.status_code, 200)
+        self.assertIn(b"That phone number is already assigned to another user.", duplicate.data)
+
+        blocked = self.client.get("/dashboard", follow_redirects=False)
+        self.assertEqual(blocked.status_code, 302)
+        self.assertIn("/account/security-contact", blocked.headers.get("Location", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_security_events_routes.py
+++ b/tests/test_security_events_routes.py
@@ -1,0 +1,126 @@
+import importlib
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+
+
+class TestSecurityEventsRoutes(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original_flask_debug = os.environ.get("FLASK_DEBUG")
+        os.environ["FLASK_DEBUG"] = "1"
+        self._temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(self._temp_dir.name, "test.db")
+        os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+        import app.config
+
+        importlib.reload(app.config)
+        from app import create_app, db
+        from app.models import AppUser, AuthEvent
+
+        self.db = db
+        self.AppUser = AppUser
+        self.AuthEvent = AuthEvent
+        self.app = create_app(run_startup_tasks=False, start_scheduler=False)
+        self.app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+        self._app_context = self.app.app_context()
+        self._app_context.push()
+        self.db.create_all()
+        self.client = self.app.test_client()
+
+        admin = self.AppUser(username="admin", phone="+15550006001", role="admin", must_change_password=False)
+        admin.set_password("Admin-pass1!")
+        viewer = self.AppUser(username="viewer", phone="+15550006002", role="viewer", must_change_password=False)
+        viewer.set_password("Viewer-pass1!")
+        self.db.session.add_all([admin, viewer])
+        self.db.session.flush()
+
+        match_event = self.AuthEvent(
+            event_type="login_failure",
+            outcome="failed",
+            username="admin",
+            user_id=admin.id,
+            client_ip="10.0.0.10",
+            created_at=datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc),
+        )
+        match_event.set_metadata({"marker": "match-row"})
+
+        old_event = self.AuthEvent(
+            event_type="password_changed",
+            outcome="success",
+            username="admin",
+            user_id=admin.id,
+            client_ip="10.0.0.11",
+            created_at=datetime(2026, 1, 2, 10, 0, tzinfo=timezone.utc),
+        )
+        old_event.set_metadata({"marker": "old-row"})
+
+        viewer_event = self.AuthEvent(
+            event_type="login_success",
+            outcome="success",
+            username="viewer",
+            user_id=viewer.id,
+            client_ip="10.0.0.12",
+            created_at=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc),
+        )
+        viewer_event.set_metadata({"marker": "viewer-row"})
+
+        self.db.session.add_all([match_event, old_event, viewer_event])
+        self.db.session.commit()
+
+    def tearDown(self) -> None:
+        self.db.session.remove()
+        self.db.drop_all()
+        self.db.engine.dispose()
+        self._app_context.pop()
+        self._temp_dir.cleanup()
+        if self._original_flask_debug is None:
+            os.environ.pop("FLASK_DEBUG", None)
+        else:
+            os.environ["FLASK_DEBUG"] = self._original_flask_debug
+        os.environ.pop("DATABASE_URL", None)
+
+    def _login(self, username: str, password: str):
+        return self.client.post(
+            "/login",
+            data={"username": username, "password": password},
+            follow_redirects=False,
+        )
+
+    def test_security_events_route_is_admin_only(self) -> None:
+        self._login("admin", "Admin-pass1!")
+        admin_response = self.client.get("/security/events", follow_redirects=False)
+        self.assertEqual(admin_response.status_code, 200)
+        self.assertIn(b"Security Events", admin_response.data)
+
+        self.client.post("/logout", follow_redirects=False)
+        self._login("viewer", "Viewer-pass1!")
+        viewer_response = self.client.get("/security/events", follow_redirects=False)
+        self.assertEqual(viewer_response.status_code, 403)
+
+    def test_security_events_filters_by_username_event_outcome(self) -> None:
+        self._login("admin", "Admin-pass1!")
+        filtered = self.client.get(
+            "/security/events?username=admin&event_type=login_failure&outcome=failed",
+            follow_redirects=False,
+        )
+        self.assertEqual(filtered.status_code, 200)
+        self.assertIn(b"match-row", filtered.data)
+        self.assertNotIn(b"old-row", filtered.data)
+        self.assertNotIn(b"viewer-row", filtered.data)
+
+    def test_security_events_filters_by_date_range(self) -> None:
+        self._login("admin", "Admin-pass1!")
+        filtered = self.client.get(
+            "/security/events?date_from=2026-01-10&date_to=2026-01-20",
+            follow_redirects=False,
+        )
+        self.assertEqual(filtered.status_code, 200)
+        self.assertIn(b"match-row", filtered.data)
+        self.assertIn(b"viewer-row", filtered.data)
+        self.assertNotIn(b"old-row", filtered.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_creation.py
+++ b/tests/test_user_creation.py
@@ -29,7 +29,12 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
         self.db.create_all()
         self.client = self.app.test_client()
 
-        admin = self.AppUser(username="admin", role="admin", must_change_password=False)
+        admin = self.AppUser(
+            username="admin",
+            phone="+15550000009",
+            role="admin",
+            must_change_password=False,
+        )
         admin.set_password("admin-pass")
         self.db.session.add(admin)
         self.db.session.commit()
@@ -60,7 +65,8 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
             data={
                 "username": "new-user",
                 "role": "social_manager",
-                "password": "new-password-123",
+                "phone": "+15551110001",
+                "password": "Stronger-pass1!",
             },
             follow_redirects=False,
         )
@@ -77,7 +83,8 @@ class TestUserCreationMustChangePassword(unittest.TestCase):
             data={
                 "username": "new-user-2",
                 "role": "social_manager",
-                "password": "new-password-123",
+                "phone": "+15551110002",
+                "password": "Stronger-pass1!",
                 "must_change_password": "on",
             },
             follow_redirects=False,


### PR DESCRIPTION
## Summary
This PR implements the full auth/password hardening plan and closes all remaining Phase 4 gaps.

### Auth/session hardening
- Convert logout to `POST /logout` with CSRF-backed form submission.
- Enforce nonce-bound sessions via `AppUser.get_id()` (`id:session_nonce`) and nonce validation in user loader.
- Apply session-fixation mitigation (`session.clear()` before `login_user`).
- Force full re-login after successful password change.

### Password and account controls
- Add password policy enforcement (12+ chars, lower/upper/digit/symbol, username exclusion).
- Add current/recent password reuse prevention via `user_password_history`.
- Add account/IP lockout tracking with username-aware records and lockout state checks.

### Security contact + alerting
- Add mandatory security contact flow: `GET/POST /account/security-contact`.
- Require phone for app users in create/edit flows.
- Add non-blocking SMS security alerts (password changed, admin reset, lockout) with audit logging when alert send fails.

### Security audit visibility and retention
- Add auth event model/table and admin UI: `GET /security/events`.
- Add auth event retention pruning (`AUTH_EVENT_RETENTION_DAYS`, default 180).

### Migration and configuration
- Add migration `010_add_auth_hardening_tables_and_columns.py` for:
  - `users.phone`
  - `users.session_nonce` (+ backfill)
  - `login_attempts.username` (+ composite index)
  - `user_password_history`
  - `auth_events`
- Add config keys for remember-cookie duration, password history count, lockout tuning, alert enablement, event retention.

### Plan-completion testing updates
- Add explicit Phase 4 suites:
  - `tests/test_password_policy.py`
  - `tests/test_auth_session_invalidation.py`
  - `tests/test_login_lockout.py`
  - `tests/test_security_contact_gate.py`
  - `tests/test_security_events_routes.py`
- Add `pytest.ini` (`testpaths = tests`) to avoid nested test-tree collection conflicts.
- Update existing tests impacted by logout method/phone requirement/password-change behavior.

## Verification
- `./venv/bin/python -m pytest -q tests/test_password_policy.py tests/test_auth_session_invalidation.py tests/test_login_lockout.py tests/test_security_contact_gate.py tests/test_security_events_routes.py`
  - `12 passed`
- `./venv/bin/python -m pytest -q`
  - `163 passed`

## Notes
- `.coverage` is intentionally not included in this PR.
