### PR TITLE
Align page header actions and simplify row-actions overflow sizing

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -390,6 +390,12 @@ h6,
   display: flex;
   gap: var(--space-2);
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.app-page-actions-inline .btn {
+  display: inline-flex;
+  align-items: center;
 }
 
 .app-page-actions-overflow {
@@ -648,9 +654,13 @@ h6,
 }
 
 .row-actions .row-actions__overflow-toggle {
-  min-width: 2.5rem;
+  min-width: 2.25rem;
   padding: var(--space-1) var(--space-2);
   line-height: 1.2;
+}
+
+.row-actions .row-actions__overflow {
+  display: inline-flex;
 }
 
 .row-actions__overflow-toggle::after {
@@ -700,7 +710,9 @@ h6,
     flex: 1 1 auto;
   }
 
-  .row-actions[data-row-actions] .row-actions__primary > form .btn {
+  .row-actions[data-row-actions] .row-actions__primary > form .btn,
+  .row-actions[data-row-actions] .row-actions__primary > .btn,
+  .row-actions[data-row-actions] .row-actions__primary > .btn-group .btn {
     width: 100%;
     justify-content: center;
   }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -396,19 +396,13 @@
                     primaryContainer.appendChild(item);
                 });
 
-                const hasSmallGroup = primaryItems.some((item) => {
-                    if (!(item instanceof HTMLElement)) {
-                        return false;
-                    }
-                    return item.classList.contains('btn-group-sm') || Boolean(item.querySelector('.btn-group-sm'));
-                });
                 const hasSmallButtons = primaryItems.some((item) => {
                     if (!(item instanceof HTMLElement)) {
                         return false;
                     }
                     return item.matches('.btn-sm') || Boolean(item.querySelector('.btn-sm'));
                 });
-                const toggleSizeClass = hasSmallButtons && !hasSmallGroup ? ' btn-sm' : '';
+                const toggleSizeClass = hasSmallButtons ? ' btn-sm' : '';
 
                 const overflowContainer = document.createElement('div');
                 overflowContainer.className = 'dropdown row-actions__overflow';


### PR DESCRIPTION
### Motivation
- Page header action controls (e.g. "Keyword Rules" and "Add Survey Flow") were top-aligned and visually inconsistent, so header actions must vertically center and keep icon/text alignment consistent.
- The overflow toggle sizing logic used a fragile small-group detection heuristic which caused inconsistent toggle sizing when primary buttons were small, so it should inherit `btn-sm` whenever primary actions contain small buttons.

### Description
- Center header action controls by adding `align-items: center` to `.app-page-actions-inline` in `app/static/css/app.css` and make header buttons render as `inline-flex` with centered content via `.app-page-actions-inline .btn`.
- Simplify the overflow toggle sizing heuristic in `app/templates/base.html` by removing the `hasSmallGroup` check and applying the `btn-sm` class when any primary item matches `.btn-sm` (i.e. `toggleSizeClass` now depends only on `hasSmallButtons`).
- Tweak row-actions layout and sizing: reduce `.row-actions__overflow-toggle` `min-width`, make `.row-actions__overflow` `inline-flex`, and expand mobile centering rules so direct `.btn` and `.btn-group .btn` also become full-width and center their content under the mobile breakpoint in `app/static/css/app.css`.

### Testing
- Ran the test suite with `pytest -q`, which succeeded: `174 passed`.
- Executed a Playwright smoke script that logs in and captures `inbox/surveys` header layout, which completed and produced `surveys-header-align.png`, confirming the visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a47f4d6608324bbfc983e4892a443)