### PR TITLE
Inbox opt-out compliance: block sends and align suppression metadata

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2570,6 +2570,7 @@ def inbox_list():
     messages = []
     active_sessions = []
     active_trigger_keywords: set[str] = set()
+    selected_thread_is_unsubscribed = False
     if selected_thread:
         if selected_thread.unread_count:
             mark_thread_read(selected_thread.id)
@@ -2581,6 +2582,9 @@ def inbox_list():
             thread_id=selected_thread.id,
             status='active',
         ).order_by(SurveySession.started_at.desc()).all()
+        selected_thread_is_unsubscribed = (
+            UnsubscribedContact.query.filter_by(phone=selected_thread.phone).first() is not None
+        )
 
     thread_display_names = _build_thread_display_names(threads, selected_thread=selected_thread)
     latest_message_id = db.session.query(func.max(InboxMessage.id)).scalar() or 0
@@ -2592,6 +2596,7 @@ def inbox_list():
         messages=messages,
         active_sessions=active_sessions,
         active_trigger_keywords=active_trigger_keywords,
+        selected_thread_is_unsubscribed=selected_thread_is_unsubscribed,
         thread_display_names=thread_display_names,
         inbox_status_latest_message_id=latest_message_id,
         search=search,
@@ -2624,6 +2629,8 @@ def inbox_reply(thread_id):
 
     if result.get('success'):
         flash('Reply sent.', 'success')
+    elif result.get('status') == 'blocked_opt_out':
+        flash('Reply blocked: this contact is unsubscribed. Ask them to text START to resubscribe.', 'warning')
     else:
         error = result.get('error') or 'Unknown error'
         flash(f'Reply could not be delivered: {error}', 'error')

--- a/app/services/inbox_service.py
+++ b/app/services/inbox_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app import db
 from app.models import (
+    CommunityMember,
     EventRegistration,
     InboxMessage,
     InboxThread,
@@ -15,6 +16,7 @@ from app.models import (
     UnsubscribedContact,
     utc_now,
 )
+from app.services.suppression_service import classify_failure
 from app.services.twilio_service import get_twilio_service
 from app.utils import normalize_keyword, normalize_phone, validate_phone
 
@@ -174,11 +176,29 @@ def send_thread_reply(thread_id: int, body: str, actor: str | None = None) -> di
     if not reply_body:
         return {'success': False, 'error': 'empty_message'}
 
+    if UnsubscribedContact.query.filter_by(phone=thread.phone).first():
+        return {
+            'success': False,
+            'status': 'blocked_opt_out',
+            'sid': None,
+            'error': 'Cannot send to unsubscribed recipient. They must reply START to resubscribe.',
+        }
+
     try:
         twilio = get_twilio_service()
         result = twilio.send_message(thread.phone, reply_body)
     except Exception as exc:
         result = {'success': False, 'status': 'failed', 'sid': None, 'error': str(exc)}
+
+    if not result.get('success'):
+        error_text = result.get('error') or ''
+        if classify_failure(error_text) == 'opt_out':
+            _upsert_unsubscribed(
+                thread.phone,
+                error_text or 'Manual reply blocked by Twilio opt-out',
+                source='message_failure',
+                name=_resolve_unsubscribed_name(thread.phone, thread=thread),
+            )
 
     _append_inbox_message(
         thread,
@@ -193,6 +213,28 @@ def send_thread_reply(thread_id: int, body: str, actor: str | None = None) -> di
     )
     db.session.commit()
     return result
+
+
+def _normalize_unsubscribed_name(name: str | None) -> str | None:
+    normalized = (name or '').strip()
+    if not normalized:
+        return None
+    return normalized[:100]
+
+
+def _resolve_unsubscribed_name(phone: str, thread: InboxThread | None = None) -> str | None:
+    community_member = CommunityMember.query.filter_by(phone=phone).first()
+    if community_member:
+        community_name = _normalize_unsubscribed_name(community_member.name)
+        if community_name:
+            return community_name
+
+    if thread is None:
+        thread = InboxThread.query.filter_by(phone=phone).first()
+    if thread is None:
+        return None
+
+    return _normalize_unsubscribed_name(thread.contact_name)
 
 
 def _get_or_create_thread(phone: str, contact_name: str | None = None) -> InboxThread:
@@ -318,17 +360,27 @@ def _send_automated_reply(
     return result
 
 
-def _upsert_unsubscribed(phone: str, reason: str) -> None:
+def _upsert_unsubscribed(
+    phone: str,
+    reason: str,
+    *,
+    source: str = 'inbound',
+    name: str | None = None,
+) -> None:
+    resolved_name = _normalize_unsubscribed_name(name)
     entry = UnsubscribedContact.query.filter_by(phone=phone).first()
     if entry:
         entry.reason = reason or entry.reason
-        entry.source = 'inbound'
+        entry.source = source or entry.source
+        if not entry.name and resolved_name:
+            entry.name = resolved_name
         return
     db.session.add(
         UnsubscribedContact(
+            name=resolved_name,
             phone=phone,
             reason=reason or None,
-            source='inbound',
+            source=source or 'inbound',
         )
     )
 
@@ -647,15 +699,13 @@ def process_inbound_sms(payload: dict) -> dict:
 
     session = _active_session(phone)
     if normalized in STOP_KEYWORDS:
-        _upsert_unsubscribed(phone, 'Inbound STOP keyword received')
-        _cancel_active_sessions(phone)
-        pending_replies.append(
-            {
-                'source': 'system',
-                'source_id': None,
-                'body': 'You are unsubscribed and will no longer receive SMS alerts. Reply START to resubscribe.',
-            }
+        _upsert_unsubscribed(
+            phone,
+            'Inbound STOP keyword received',
+            source='inbound',
+            name=_resolve_unsubscribed_name(phone, thread=thread),
         )
+        _cancel_active_sessions(phone)
         status = 'opt_out'
     elif session and normalized in SURVEY_CANCEL_KEYWORDS:
         now = utc_now()

--- a/app/templates/inbox/list.html
+++ b/app/templates/inbox/list.html
@@ -155,6 +155,12 @@
                     {% endfor %}
                 </div>
                 {% endif %}
+                {% if selected_thread_is_unsubscribed %}
+                <div class="alert alert-warning py-2">
+                    <i class="bi bi-shield-exclamation me-1"></i>
+                    This contact is unsubscribed. They must text <strong>START</strong>, <strong>UNSTOP</strong>, or <strong>YES</strong> to receive messages again.
+                </div>
+                {% endif %}
 
                 <form id="bulkMessageDeleteForm" method="POST" action="{{ url_for('main.inbox_messages_bulk_delete') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -235,8 +241,9 @@
                     <label for="replyBody" class="form-label">Send reply</label>
                     <div class="input-group">
                         <textarea id="replyBody" name="body" class="form-control" rows="2" maxlength="1600"
-                                  placeholder="Type your reply..." required></textarea>
-                        <button class="btn btn-primary" type="submit">
+                                  placeholder="{{ 'Contact must reply START/UNSTOP/YES to resubscribe before you can send.' if selected_thread_is_unsubscribed else 'Type your reply...' }}"
+                                  required{% if selected_thread_is_unsubscribed %} disabled{% endif %}></textarea>
+                        <button class="btn btn-primary" type="submit"{% if selected_thread_is_unsubscribed %} disabled{% endif %}>
                             <i class="bi bi-send me-1"></i>Send
                         </button>
                     </div>

--- a/docs/api.md
+++ b/docs/api.md
@@ -501,6 +501,7 @@ POST /inbox/messages/bulk-delete
 ```
 
 Inbox mutations (`reply`, `thread update/delete`, `message bulk delete`) require `admin` or `social_manager`.
+Inbox replies are blocked for unsubscribed contacts until they text `START`, `UNSTOP`, or `YES`.
 
 ### Keyword Automations
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -166,6 +166,7 @@ Phone numbers that have opted out and should not receive messages.
 - `import` - CSV import
 - `community` - Unsubscribed from community list
 - `event:{id}` - Unsubscribed from event registration
+- `inbound` - Inbound STOP/UNSUBSCRIBE/CANCEL keyword received
 - `message_failure` - Auto-detected from Twilio opt-out error
 
 ### SuppressedContact

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,7 +154,11 @@ TWILIO_FROM_NUMBER=+1xxxx
 
 **Cause:** Recipient replied STOP.
 
-**Behavior:** Automatically added to `unsubscribed_contacts`.
+**Behavior:**
+- Automatically added to `unsubscribed_contacts`.
+- Inbox manual replies are blocked while unsubscribed.
+- The app does not send a custom STOP confirmation SMS; rely on carrier/Twilio opt-out handling.
+- Recipient must reply `START` (or `UNSTOP` / `YES`) to resubscribe before sends can resume.
 
 ---
 

--- a/tests/test_inbox_routes.py
+++ b/tests/test_inbox_routes.py
@@ -27,6 +27,7 @@ class TestInboxRoutes(unittest.TestCase):
             SurveyFlow,
             SurveyResponse,
             SurveySession,
+            UnsubscribedContact,
         )
 
         self.db = db
@@ -37,6 +38,7 @@ class TestInboxRoutes(unittest.TestCase):
         self.SurveyFlow = SurveyFlow
         self.SurveySession = SurveySession
         self.SurveyResponse = SurveyResponse
+        self.UnsubscribedContact = UnsubscribedContact
 
         self.app = create_app(run_startup_tasks=False, start_scheduler=False)
         self.app.config.update(
@@ -603,6 +605,57 @@ class TestInboxRoutes(unittest.TestCase):
         self.assertNotIn("selectAllThreads", html)
         self.assertNotIn("bulkThreadDeleteForm", html)
         self.assertNotIn(f"/inbox/messages/{message.id}/delete", html)
+
+    def test_inbox_ui_disables_reply_for_unsubscribed_thread(self) -> None:
+        self._login()
+        thread = self._create_thread(phone="+17205550015")
+        self.db.session.add(
+            self.UnsubscribedContact(
+                phone=thread.phone,
+                reason="Inbound STOP keyword received",
+                source="inbound",
+            )
+        )
+        self.db.session.commit()
+
+        response = self.client.get(f"/inbox?thread={thread.id}")
+        self.assertEqual(response.status_code, 200)
+        html = response.get_data(as_text=True)
+        self.assertIn("This contact is unsubscribed.", html)
+        self.assertIn(
+            "Contact must reply START/UNSTOP/YES to resubscribe before you can send.",
+            html,
+        )
+        self.assertIn('<textarea id="replyBody"', html)
+        self.assertIn('id="replyBody" name="body" class="form-control"', html)
+        self.assertIn('disabled></textarea>', html)
+        self.assertIn('<button class="btn btn-primary" type="submit" disabled>', html)
+
+    def test_inbox_reply_post_blocked_for_unsubscribed_thread(self) -> None:
+        self._login()
+        thread = self._create_thread(phone="+17205550016")
+        self.db.session.add(
+            self.UnsubscribedContact(
+                phone=thread.phone,
+                reason="Inbound STOP keyword received",
+                source="inbound",
+            )
+        )
+        self.db.session.commit()
+
+        response = self.client.post(
+            f"/inbox/{thread.id}/reply",
+            data={"body": "Hello there"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            b"Reply blocked: this contact is unsubscribed. Ask them to text START to resubscribe.",
+            response.data,
+        )
+
+        outbound_count = self.InboxMessage.query.filter_by(thread_id=thread.id, direction="outbound").count()
+        self.assertEqual(outbound_count, 0)
 
     def test_survey_submissions_requires_login(self) -> None:
         survey = self._create_survey_flow(

--- a/tests/test_inbox_service.py
+++ b/tests/test_inbox_service.py
@@ -19,6 +19,7 @@ class TestInboxService(unittest.TestCase):
         importlib.reload(app.config)
         from app import create_app, db
         from app.models import (
+            CommunityMember,
             Event,
             EventRegistration,
             InboxMessage,
@@ -29,8 +30,9 @@ class TestInboxService(unittest.TestCase):
             SurveySession,
             UnsubscribedContact,
         )
-        from app.services.inbox_service import process_inbound_sms
+        from app.services.inbox_service import process_inbound_sms, send_thread_reply
 
+        self.CommunityMember = CommunityMember
         self.db = db
         self.Event = Event
         self.EventRegistration = EventRegistration
@@ -42,6 +44,7 @@ class TestInboxService(unittest.TestCase):
         self.SurveyResponse = SurveyResponse
         self.UnsubscribedContact = UnsubscribedContact
         self.process_inbound_sms = process_inbound_sms
+        self.send_thread_reply = send_thread_reply
 
         self.app = create_app(run_startup_tasks=False, start_scheduler=False)
         self.app.config.update(
@@ -764,6 +767,8 @@ class TestInboxService(unittest.TestCase):
 
         unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15551112222").first()
         self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.source, "inbound")
+        self.assertEqual(unsubscribed.reason, "Inbound STOP keyword received")
 
         thread = self.InboxThread.query.filter_by(phone="+15551112222").first()
         messages = (
@@ -771,12 +776,8 @@ class TestInboxService(unittest.TestCase):
             .order_by(self.InboxMessage.created_at.asc())
             .all()
         )
-        self.assertTrue(
-            any(
-                msg.direction == "outbound"
-                and "You are unsubscribed and will no longer receive SMS alerts." in msg.body
-                for msg in messages
-            )
+        self.assertFalse(
+            any("You are unsubscribed and will no longer receive SMS alerts." in msg.body for msg in messages)
         )
 
     @patch("app.services.inbox_service.get_twilio_service")
@@ -797,6 +798,18 @@ class TestInboxService(unittest.TestCase):
 
         unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15556667777").first()
         self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.source, "inbound")
+        self.assertEqual(unsubscribed.reason, "Inbound STOP keyword received")
+
+        thread = self.InboxThread.query.filter_by(phone="+15556667777").first()
+        self.assertIsNotNone(thread)
+        messages = (
+            self.InboxMessage.query.filter_by(thread_id=thread.id)
+            .order_by(self.InboxMessage.created_at.asc())
+            .all()
+        )
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].direction, "inbound")
 
     @patch("app.services.inbox_service.get_twilio_service")
     def test_stop_then_start_updates_unsubscribe_state(self, mock_get_twilio) -> None:
@@ -815,6 +828,8 @@ class TestInboxService(unittest.TestCase):
         self.assertEqual(stop_result["status"], "opt_out")
         unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15554443333").first()
         self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.source, "inbound")
+        self.assertEqual(unsubscribed.reason, "Inbound STOP keyword received")
 
         start_result = self.process_inbound_sms(
             {"From": "+15554443333", "Body": "START", "MessageSid": "SM-IN-6"}
@@ -822,6 +837,123 @@ class TestInboxService(unittest.TestCase):
         self.assertEqual(start_result["status"], "opt_in")
         unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15554443333").first()
         self.assertIsNone(unsubscribed)
+
+    def test_stop_unsubscribe_prefers_community_name_over_thread_name(self) -> None:
+        self.db.session.add(self.CommunityMember(name="Community Name", phone="+15553334444"))
+        self.db.session.commit()
+
+        stop_result = self.process_inbound_sms(
+            {
+                "From": "+15553334444",
+                "Body": "STOP",
+                "MessageSid": "SM-IN-COMMUNITY-NAME-STOP",
+                "ProfileName": "Thread Name",
+            }
+        )
+        self.assertEqual(stop_result["status"], "opt_out")
+
+        unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15553334444").first()
+        self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.name, "Community Name")
+        self.assertEqual(unsubscribed.source, "inbound")
+
+    def test_stop_unsubscribe_uses_thread_name_when_community_missing(self) -> None:
+        stop_result = self.process_inbound_sms(
+            {
+                "From": "+15553335555",
+                "Body": "STOP",
+                "MessageSid": "SM-IN-THREAD-NAME-STOP",
+                "ProfileName": "Thread Name",
+            }
+        )
+        self.assertEqual(stop_result["status"], "opt_out")
+
+        unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15553335555").first()
+        self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.name, "Thread Name")
+        self.assertEqual(unsubscribed.source, "inbound")
+
+    def test_stop_unsubscribe_keeps_existing_name(self) -> None:
+        self.db.session.add(
+            self.UnsubscribedContact(
+                name="Existing Name",
+                phone="+15553336666",
+                reason="Old reason",
+                source="manual",
+            )
+        )
+        self.db.session.commit()
+
+        stop_result = self.process_inbound_sms(
+            {
+                "From": "+15553336666",
+                "Body": "STOP",
+                "MessageSid": "SM-IN-KEEP-NAME-STOP",
+                "ProfileName": "Thread Name",
+            }
+        )
+        self.assertEqual(stop_result["status"], "opt_out")
+
+        unsubscribed = self.UnsubscribedContact.query.filter_by(phone="+15553336666").first()
+        self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.name, "Existing Name")
+        self.assertEqual(unsubscribed.reason, "Inbound STOP keyword received")
+        self.assertEqual(unsubscribed.source, "inbound")
+
+    @patch("app.services.inbox_service.get_twilio_service")
+    def test_send_thread_reply_blocks_when_recipient_is_unsubscribed(self, mock_get_twilio) -> None:
+        thread = self.InboxThread(phone="+15554445555", contact_name="Thread Name")
+        self.db.session.add(thread)
+        self.db.session.add(
+            self.UnsubscribedContact(
+                phone=thread.phone,
+                reason="Inbound STOP keyword received",
+                source="inbound",
+            )
+        )
+        self.db.session.commit()
+
+        result = self.send_thread_reply(thread.id, "Hello from admin", actor="admin")
+        self.assertFalse(result["success"])
+        self.assertEqual(result["status"], "blocked_opt_out")
+        mock_get_twilio.assert_not_called()
+
+        outbound_count = self.InboxMessage.query.filter_by(thread_id=thread.id, direction="outbound").count()
+        self.assertEqual(outbound_count, 0)
+
+    @patch("app.services.inbox_service.get_twilio_service")
+    def test_send_thread_reply_opt_out_failure_upserts_unsubscribed_with_message_failure_source(self, mock_get_twilio) -> None:
+        thread = self.InboxThread(phone="+15554446666", contact_name="Thread Name")
+        self.db.session.add(thread)
+        self.db.session.add(self.CommunityMember(name="Community Name", phone=thread.phone))
+        self.db.session.commit()
+
+        mock_service = MagicMock()
+        mock_service.send_message.return_value = {
+            "success": False,
+            "sid": None,
+            "status": "failed",
+            "error": "Attempt to send to unsubscribed recipient (21610)",
+        }
+        mock_get_twilio.return_value = mock_service
+
+        result = self.send_thread_reply(thread.id, "Hello from admin", actor="admin")
+        self.assertFalse(result["success"])
+
+        unsubscribed = self.UnsubscribedContact.query.filter_by(phone=thread.phone).first()
+        self.assertIsNotNone(unsubscribed)
+        self.assertEqual(unsubscribed.name, "Community Name")
+        self.assertEqual(unsubscribed.source, "message_failure")
+        self.assertEqual(unsubscribed.reason, "Attempt to send to unsubscribed recipient (21610)")
+
+        outbound_message = (
+            self.InboxMessage.query.filter_by(thread_id=thread.id, direction="outbound")
+            .order_by(self.InboxMessage.id.desc())
+            .first()
+        )
+        self.assertIsNotNone(outbound_message)
+        self.assertEqual(outbound_message.delivery_status, "failed")
+        self.assertEqual(outbound_message.delivery_error, "Attempt to send to unsubscribed recipient (21610)")
 
     @patch("app.services.inbox_service.get_twilio_service")
     def test_start_when_already_subscribed_sends_ack(self, mock_get_twilio) -> None:


### PR DESCRIPTION
## Summary
- Block manual Inbox replies for unsubscribed contacts before attempting Twilio send.
- Add unsubscribed-state UI in Inbox (warning banner + disabled composer/send).
- Stop sending app-generated STOP/CANCEL unsubscribe acknowledgement SMS in inbound flow.
- Auto-upsert `unsubscribed_contacts` on manual send failures classified as Twilio opt-out.
- Align unsubscribe metadata handling with existing suppression conventions:
  - `source='inbound'` for STOP keyword events.
  - `source='message_failure'` for Twilio opt-out send failures.
  - Name resolution priority: Community member name, then thread contact name.
  - Only fill missing names on existing rows; preserve original `created_at`.
- Update docs for inbound source value and Inbox opt-out behavior.

## Testing
- `./venv/bin/pytest -q tests/test_inbox_service.py`
- `./venv/bin/pytest -q tests/test_inbox_routes.py`

## Notes
- No schema/migration changes.
- No API endpoint additions/removals.
