### PR TITLE
Harden CSV export sanitization for whitespace-prefixed formulas

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -120,7 +120,11 @@ def sanitize_csv_cell(value: object) -> str:
     if not text:
         return text
 
-    if text[0] in _CSV_FORMULA_PREFIXES or text[0] in ("\t", "\r", "\n"):
+    stripped = text.lstrip(" \t\r\n")
+    if stripped and stripped[0] in _CSV_FORMULA_PREFIXES:
+        return f"'{text}"
+
+    if text[0] in ("\t", "\r", "\n"):
         return f"'{text}"
     return text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,6 +64,10 @@ class TestSanitizeCsvCell(unittest.TestCase):
         self.assertEqual(sanitize_csv_cell("\nhello"), "'\nhello")
         self.assertEqual(sanitize_csv_cell("\rhello"), "'\rhello")
 
+    def test_leading_whitespace_before_formula_is_escaped(self) -> None:
+        self.assertEqual(sanitize_csv_cell("  =SUM(A1:A2)"), "'  =SUM(A1:A2)")
+        self.assertEqual(sanitize_csv_cell(" \t-10"), "' \t-10")
+
     def test_regular_values_are_not_changed(self) -> None:
         self.assertEqual(sanitize_csv_cell("hello"), "hello")
         self.assertEqual(sanitize_csv_cell("12345"), "12345")


### PR DESCRIPTION
### Motivation
- Close a CSV formula-injection bypass where dangerous formula characters could be hidden behind leading whitespace or control characters in exported CSV cells.

### Description
- Update `sanitize_csv_cell()` to strip leading whitespace/control characters before checking for formula-prefix characters and escape the original cell when a formula is detected (file: `app/utils.py`).
- Add regression tests for whitespace-prefixed formula payloads to `tests/test_utils.py` to ensure leading spaces/tabs before `=`, `+`, `-`, or `@` are escaped.

### Testing
- Ran focused tests: `pytest -q tests/test_utils.py tests/test_export_csv_security.py` which passed (`28 passed`).
- Ran full suite: `pytest -q` which succeeded (`193 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf272500c83249ebcc9b3e193310d)