### PR TITLE
Normalize numeric phone inputs, add log/dashboard tests, and clean up route imports

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1894,7 +1894,6 @@ def logs_list():
     try:
         logs = query.order_by(MessageLog.created_at.desc()).limit(100).all()
     except OperationalError as exc:
-        from flask import current_app
         current_app.logger.warning(
             'MessageLog list query failed due to schema mismatch: %s',
             exc,
@@ -1927,7 +1926,6 @@ def log_detail(log_id):
     try:
         log = db.get_or_404(MessageLog, log_id)
     except OperationalError as exc:
-        from flask import current_app
         current_app.logger.warning(
             'MessageLog detail query failed due to schema mismatch: %s',
             exc,

--- a/app/utils.py
+++ b/app/utils.py
@@ -28,15 +28,17 @@ def normalize_keyword(value: str) -> str:
     return ' '.join((value or '').upper().strip().split())
 
 
-def normalize_phone(phone: str) -> str:
+def normalize_phone(phone: object) -> str:
     """
     Normalize phone number to E.164-ish format.
     Removes non-digit characters and ensures it starts with +.
     """
-    if not phone:
+    if phone is None:
         return ''
 
-    raw = phone.strip()
+    raw = str(phone).strip()
+    if not raw:
+        return ''
     digits = re.sub(r'\D', '', raw)
     if not digits:
         return ''

--- a/tests/test_logs_routes.py
+++ b/tests/test_logs_routes.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import MagicMock, patch
 
 
 class TestLogsRoutes(unittest.TestCase):
@@ -17,10 +18,11 @@ class TestLogsRoutes(unittest.TestCase):
 
         importlib.reload(app.config)
         from app import create_app, db
-        from app.models import AppUser, MessageLog
+        from app.models import AppUser, CommunityMember, MessageLog
 
         self.db = db
         self.AppUser = AppUser
+        self.CommunityMember = CommunityMember
         self.MessageLog = MessageLog
 
         self.app = create_app(run_startup_tasks=False, start_scheduler=False)
@@ -99,6 +101,26 @@ class TestLogsRoutes(unittest.TestCase):
         self.assertIn("+15551234567", html)
         self.assertIn("Carrier rejection", html)
 
+
+    def test_log_detail_handles_numeric_phone_values(self) -> None:
+        self._login()
+        log_id = self._create_log(
+            json.dumps(
+                [
+                    {
+                        "phone": 15557654321,
+                        "success": False,
+                        "error": "Carrier rejection",
+                    }
+                ]
+            )
+        )
+
+        response = self.client.get(f"/logs/{log_id}", follow_redirects=False)
+        self.assertEqual(response.status_code, 200)
+        html = response.get_data(as_text=True)
+        self.assertIn("Carrier rejection", html)
+
     def test_log_detail_ignores_non_dict_detail_entries(self) -> None:
         self._login()
         log_id = self._create_log(
@@ -120,6 +142,55 @@ class TestLogsRoutes(unittest.TestCase):
         html = response.get_data(as_text=True)
         self.assertIn("+15557654321", html)
         self.assertIn("Temporary failure", html)
+
+    def test_log_detail_renders_when_details_json_array_is_empty(self) -> None:
+        self._login()
+        log_id = self._create_log("[]")
+
+        response = self.client.get(f"/logs/{log_id}", follow_redirects=False)
+        self.assertEqual(response.status_code, 200)
+        html = response.get_data(as_text=True)
+        self.assertIn("Message Log Details", html)
+
+    def test_dashboard_send_redirects_to_log_detail_for_general_blast(self) -> None:
+        self._login()
+        self.db.session.add(self.CommunityMember(name="Member", phone="+15551234567"))
+        self.db.session.commit()
+
+        mock_queue = MagicMock()
+        with patch("app.queue.get_queue", return_value=mock_queue):
+            response = self.client.post(
+                "/dashboard",
+                data={
+                    "message_body": "Hello everyone",
+                    "target": "community",
+                },
+                follow_redirects=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Message Log Details", response.get_data(as_text=True))
+        mock_queue.enqueue.assert_called_once()
+
+    def test_dashboard_send_redirects_to_log_detail_for_test_mode(self) -> None:
+        self._login()
+        self.app.config["ADMIN_TEST_PHONE"] = "+15550009999"
+
+        mock_queue = MagicMock()
+        with patch("app.queue.get_queue", return_value=mock_queue):
+            response = self.client.post(
+                "/dashboard",
+                data={
+                    "message_body": "Test mode message",
+                    "target": "community",
+                    "test_mode": "on",
+                },
+                follow_redirects=True,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Message Log Details", response.get_data(as_text=True))
+        mock_queue.enqueue.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,9 @@ class TestNormalizePhone(unittest.TestCase):
     def test_multiple_plus_prefixes_are_normalized(self) -> None:
         self.assertEqual(normalize_phone("++++"), "")
 
+    def test_numeric_input_is_supported(self) -> None:
+        self.assertEqual(normalize_phone(17203832388), "+17203832388")
+
 
 class TestValidatePhone(unittest.TestCase):
     def test_valid_e164(self) -> None:


### PR DESCRIPTION
### Motivation
- Allow `normalize_phone` to handle numeric and non-string inputs so message logs and payloads with numeric phone values render correctly.
- Add coverage for log detail edge cases and dashboard send behavior to prevent regressions in message queuing and rendering.
- Remove redundant local imports of `current_app` in exception handlers to simplify the code.

### Description
- Updated `normalize_phone` to accept `object`, cast inputs with `str()`, return an empty string for `None` or blank values, and retain existing normalization rules for digits and prefixes.
- Added an early-return when the stringified phone is empty to avoid generating incorrect outputs for non-string inputs.
- Removed duplicate `from flask import current_app` imports inside exception handlers in `routes.py`.
- Added tests in `tests/test_utils.py` and `tests/test_logs_routes.py` to validate numeric phone normalization, handling of numeric phone values in log details, rendering when details arrays are empty, and dashboard send behavior with a mocked queue; also added `CommunityMember` import and `unittest.mock` usage in tests.

### Testing
- Ran the repository unit test suite with `python -m unittest` and all tests completed successfully.
- New tests in `tests/test_utils.py` and `tests/test_logs_routes.py` executed and passed, confirming numeric phone support and the dashboard/log behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3231559c83248c7eb92619c0647a)