### PR TITLE
Make create_app safe by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Flask SMS admin app for sending community/event SMS blasts via Twilio. Python 3.
 ```
 ./
 ├── app/                  # Core application (see app/AGENTS.md)
-│   ├── __init__.py       # App factory: create_app(), extensions, migrations, scheduler
+│   ├── __init__.py       # Pure app factory + explicit runtime bootstrap helpers
 │   ├── config.py         # Env-based config class
 │   ├── models.py         # All 15 SQLAlchemy models
 │   ├── routes.py         # Main blueprint, 40+ endpoints
@@ -83,7 +83,8 @@ Flask SMS admin app for sending community/event SMS blasts via Twilio. Python 3.
 
 - **Custom migration system**: Numbered Python files in `app/migrations/` with `apply(connection, logger)`. Tracked in `schema_migrations` table. Managed by `dbdoctor`.
 - **Dual recipient pools**: `community_members` (community blasts) and `event_registrations` (event blasts) are separate. Never cross-target.
-- **Scheduler dual-mode**: APScheduler (dev, `SCHEDULER_ENABLED=1`) vs systemd timer (prod). Runner flag: `SCHEDULER_RUNNER=1`.
+- **Pure app factory**: `create_app()` is safe by default; runtime entrypoints call `create_runtime_app()` when they need DB bootstrap and optional scheduler startup.
+- **Scheduler dual-mode**: APScheduler (dev, explicit runtime startup when `SCHEDULER_ENABLED=1`) vs systemd timer (prod).
 - **RQ jobs create own app context**: `create_app(run_startup_tasks=False, start_scheduler=False)` inside each job.
 - **CSV formula injection prevention**: `sanitize_csv_cell()` prefixes dangerous characters with `'`.
 - **Keyword normalization**: Keywords uppercased and whitespace-collapsed via `normalize_keyword()`. Uniqueness enforced across `KeywordAutomationRule` and `SurveyFlow` tables.
@@ -122,6 +123,6 @@ journalctl -u sms-scheduler.service -f # Watch scheduler logs
 - `ExecStartPre=dbdoctor --apply` in systemd units auto-runs migrations on restart.
 - Login rate limiting: 5 attempts / 5 min window, 10 min lockout. Tracked in `login_attempts` table.
 - `SECRET_KEY` must be changed in production (runtime error if default + non-debug).
-- Admin user auto-created on first run if `ADMIN_PASSWORD` set.
+- Admin user auto-created on first runtime startup if `ADMIN_PASSWORD` set.
 - Scheduled messages expire if older than `SCHEDULED_MESSAGE_MAX_LAG` minutes (default 1440 = 24h).
 - Suppression backfill available as RQ job: `backfill_suppressions_job()`.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -1,6 +1,6 @@
 # app/ — Core Application
 
-Flask application package. Entry point: `create_app()` in `__init__.py`.
+Flask application package. Runtime entrypoints use `create_runtime_app()`; `create_app()` is the pure app factory in `__init__.py`.
 
 Supported runtime for this project is Python 3.11.
 
@@ -8,7 +8,7 @@ Supported runtime for this project is Python 3.11.
 
 ```
 app/
-├── __init__.py          # App factory, extension init, migration runner, admin seed
+├── __init__.py          # Pure app factory, runtime bootstrap helpers, extension init
 ├── config.py            # All config from env vars (Config class)
 ├── models.py            # 15 SQLAlchemy models (see below)
 ├── routes.py            # Blueprint 'main', 40+ endpoints, all UI routes
@@ -65,7 +65,7 @@ app/
 
 ## CONVENTIONS (app-specific)
 
-- **App factory pattern**: `create_app()` handles extensions, blueprints, migrations, admin seed, scheduler.
+- **App factory pattern**: `create_app()` builds the Flask app only; `create_runtime_app()` performs migrations/admin bootstrap and optional scheduler startup.
 - **Two blueprints only**: `main` (routes.py) and `auth` (auth.py). Register new routes in one of these.
 - **Model validators**: Use `@validates('field')` for auto-normalization (e.g., phone, keyword).
 - **`localtime` filter**: Template filter in `__init__.py` converts UTC to client timezone via cookie.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,14 @@
 import os
-from flask import Flask, request, abort
-from flask_sqlalchemy import SQLAlchemy
-from pathlib import Path
-from typing import Optional
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import unquote
 from zoneinfo import ZoneInfo
+
+from flask import Flask, abort, request
+from flask_sqlalchemy import SQLAlchemy
 from werkzeug.middleware.proxy_fix import ProxyFix
-from flask_wtf import CSRFProtect
 from werkzeug.security import generate_password_hash
+from flask_wtf import CSRFProtect
 
 db = SQLAlchemy()
 csrf = CSRFProtect()
@@ -69,7 +69,93 @@ def _validate_production_security_config(app: Flask) -> None:
         raise RuntimeError(f"Production security configuration is invalid:\n - {details}")
 
 
-def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] = None):
+def _run_startup_tasks(app: Flask) -> None:
+    with app.app_context():
+        from app.migrations.runner import (
+            check_migrations_compatibility,
+            inspect_migrations,
+            run_pending_migrations,
+        )
+
+        check_migrations_compatibility(db.engine, app.logger)
+        db.create_all()
+
+        run_pending_migrations(db.engine, app.logger)
+        migration_report = inspect_migrations(db.engine)
+        migration_total = len(migration_report["migrations"])
+        applied = set(migration_report["applied"])
+        pending = [
+            version
+            for version in migration_report["migrations"]
+            if version not in applied
+        ]
+        app.logger.info("Database file in use: %s", migration_report["db_path"])
+        if migration_total:
+            app.logger.info(
+                "Schema migrations: %s/%s applied; pending: %s",
+                len(applied),
+                migration_total,
+                ", ".join(pending) if pending else "none",
+            )
+        else:
+            app.logger.info("Schema migrations: none")
+
+        from app.models import AppUser
+
+        if AppUser.query.count() == 0:
+            admin_password = app.config.get("ADMIN_PASSWORD")
+            if not admin_password:
+                if not app.config.get("DEBUG"):
+                    raise RuntimeError(
+                        "ADMIN_PASSWORD must be set in production to create the first admin user"
+                    )
+            else:
+                admin_username = app.config.get("ADMIN_USERNAME", "admin")
+                password_hash = admin_password
+                if not admin_password.startswith(("pbkdf2:", "scrypt:")):
+                    password_hash = generate_password_hash(
+                        admin_password, method="pbkdf2:sha256"
+                    )
+
+                admin_user = AppUser(
+                    username=admin_username,
+                    role="admin",
+                    password_hash=password_hash,
+                )
+                db.session.add(admin_user)
+                db.session.commit()
+
+
+def _configure_scheduler(app: Flask, *, start_scheduler: bool) -> None:
+    scheduler_setting = app.config.get("SCHEDULER_ENABLED")
+
+    if start_scheduler and scheduler_setting:
+        app.logger.info(
+            "Scheduler enabled (SCHEDULER_ENABLED=%s) via explicit runtime entrypoint; starting background scheduler.",
+            scheduler_setting,
+        )
+        from app.services.scheduler_service import init_scheduler
+
+        init_scheduler(app)
+    elif start_scheduler and not scheduler_setting:
+        app.logger.info(
+            "Scheduler start was requested by the runtime entrypoint, but SCHEDULER_ENABLED=%s; not starting.",
+            scheduler_setting,
+        )
+    else:
+        if scheduler_setting:
+            app.logger.warning(
+                "Scheduler enabled (SCHEDULER_ENABLED=%s) but not started (explicit runtime entrypoint not requested).",
+                scheduler_setting,
+            )
+        else:
+            app.logger.info(
+                "Scheduler disabled (SCHEDULER_ENABLED=%s); running web app only.",
+                scheduler_setting,
+            )
+
+
+def _build_app() -> Flask:
     app = Flask(__name__)
 
     @app.context_processor
@@ -151,98 +237,22 @@ def create_app(run_startup_tasks: bool = True, start_scheduler: Optional[bool] =
 
     app.register_blueprint(routes.bp)
 
+    return app
+
+
+def create_app(run_startup_tasks: bool = False, start_scheduler: bool = False) -> Flask:
+    app = _build_app()
     if run_startup_tasks:
-        # Create database tables and run migrations
-        with app.app_context():
-            from app.migrations.runner import (
-                check_migrations_compatibility,
-                inspect_migrations,
-                run_pending_migrations,
-            )
+        _run_startup_tasks(app)
 
-            check_migrations_compatibility(db.engine, app.logger)
-            db.create_all()
+    _configure_scheduler(app, start_scheduler=start_scheduler)
+    return app
 
-            run_pending_migrations(db.engine, app.logger)
-            migration_report = inspect_migrations(db.engine)
-            migration_total = len(migration_report["migrations"])
-            applied = set(migration_report["applied"])
-            pending = [
-                version
-                for version in migration_report["migrations"]
-                if version not in applied
-            ]
-            app.logger.info("Database file in use: %s", migration_report["db_path"])
-            if migration_total:
-                app.logger.info(
-                    "Schema migrations: %s/%s applied; pending: %s",
-                    len(applied),
-                    migration_total,
-                    ", ".join(pending) if pending else "none",
-                )
-            else:
-                app.logger.info("Schema migrations: none")
 
-            from app.models import AppUser
-
-            if AppUser.query.count() == 0:
-                admin_password = app.config.get("ADMIN_PASSWORD")
-                if not admin_password:
-                    if not app.config.get("DEBUG"):
-                        raise RuntimeError(
-                            "ADMIN_PASSWORD must be set in production to create the first admin user"
-                        )
-                else:
-                    admin_username = app.config.get("ADMIN_USERNAME", "admin")
-                    password_hash = admin_password
-                    if not admin_password.startswith(("pbkdf2:", "scrypt:")):
-                        password_hash = generate_password_hash(
-                            admin_password, method="pbkdf2:sha256"
-                        )
-
-                    admin_user = AppUser(
-                        username=admin_username,
-                        role="admin",
-                        password_hash=password_hash,
-                    )
-                    db.session.add(admin_user)
-                    db.session.commit()
-
-    # Start background scheduler
-    scheduler_setting = app.config.get("SCHEDULER_ENABLED")
-    if start_scheduler is None:
-        start_scheduler = os.environ.get("SCHEDULER_RUNNER") == "1"
-        scheduler_reason = "SCHEDULER_RUNNER flag"
-    else:
-        scheduler_reason = "explicit override"
-
-    if start_scheduler and scheduler_setting:
-        app.logger.info(
-            "Scheduler enabled (SCHEDULER_ENABLED=%s) via %s; starting background scheduler.",
-            scheduler_setting,
-            scheduler_reason,
-        )
-        from app.services.scheduler_service import init_scheduler
-
-        init_scheduler(app)
-    elif start_scheduler and not scheduler_setting:
-        app.logger.info(
-            "Scheduler runner requested via %s, but SCHEDULER_ENABLED=%s; not starting.",
-            scheduler_reason,
-            scheduler_setting,
-        )
-    else:
-        if scheduler_setting:
-            app.logger.warning(
-                "Scheduler enabled (SCHEDULER_ENABLED=%s) but not started (%s).",
-                scheduler_setting,
-                scheduler_reason,
-            )
-        else:
-            app.logger.info(
-                "Scheduler disabled (SCHEDULER_ENABLED=%s); running web app only (%s).",
-                scheduler_setting,
-                scheduler_reason,
-            )
+def create_runtime_app(*, start_scheduler: bool = False) -> Flask:
+    """Create the runtime app and perform explicit bootstrap side effects."""
+    app = _build_app()
+    _run_startup_tasks(app)
+    _configure_scheduler(app, start_scheduler=start_scheduler)
 
     return app

--- a/app/scheduler_runner.py
+++ b/app/scheduler_runner.py
@@ -1,7 +1,7 @@
 import signal
 import time
 
-from app import create_app
+from app import create_runtime_app
 from app.services.scheduler_service import shutdown_scheduler
 
 
@@ -18,7 +18,7 @@ signal.signal(signal.SIGINT, _handle_shutdown)
 
 
 def main():
-    create_app(start_scheduler=True)
+    app = create_runtime_app(start_scheduler=True)
 
     while not _shutdown_requested:
         time.sleep(1)

--- a/deploy/run_scheduler_once.sh
+++ b/deploy/run_scheduler_once.sh
@@ -39,7 +39,7 @@ try:
     from app import create_app
     from app.services.scheduler_service import send_scheduled_messages
 
-    app = create_app(run_startup_tasks=False)
+    app = create_app()
     send_scheduled_messages(app)
     sys.exit(0)
 except Exception as e:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,6 @@ If `DATABASE_URL` is unset, the app defaults to `instance/sms.db` under the proj
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SCHEDULER_ENABLED` | `0` (prod), `1` (dev) | Enable APScheduler background thread |
-| `SCHEDULER_RUNNER` | - | Set to `1` in scheduler service |
 | `SCHEDULED_MESSAGE_MAX_LAG` | `1440` | Minutes before scheduled message expires |
 
 ### Timezone

--- a/tests/test_scheduled_messages.py
+++ b/tests/test_scheduled_messages.py
@@ -31,7 +31,7 @@ class TestScheduledMessageProcessing(unittest.TestCase):
         import app.config
 
         importlib.reload(app.config)
-        self.app = create_app(run_startup_tasks=False)
+        self.app = create_app()
         self.app.config["TESTING"] = True
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_scheduler_mode.py
+++ b/tests/test_scheduler_mode.py
@@ -5,14 +5,16 @@ Run with: python -m unittest tests.test_scheduler_mode
 
 import os
 import unittest
+from unittest.mock import patch
 
-from app import create_app
+from app import create_app, create_runtime_app
 from app.services import scheduler_service
 
 
 class TestSchedulerMode(unittest.TestCase):
     def setUp(self) -> None:
         self._original_scheduler_enabled = os.environ.get("SCHEDULER_ENABLED")
+        self._original_scheduler_runner = os.environ.get("SCHEDULER_RUNNER")
         self._original_flask_debug = os.environ.get("FLASK_DEBUG")
         os.environ["SCHEDULER_ENABLED"] = "0"
         os.environ["FLASK_DEBUG"] = "1"
@@ -27,15 +29,35 @@ class TestSchedulerMode(unittest.TestCase):
             os.environ.pop("SCHEDULER_ENABLED", None)
         else:
             os.environ["SCHEDULER_ENABLED"] = self._original_scheduler_enabled
+        if self._original_scheduler_runner is None:
+            os.environ.pop("SCHEDULER_RUNNER", None)
+        else:
+            os.environ["SCHEDULER_RUNNER"] = self._original_scheduler_runner
         if self._original_flask_debug is None:
             os.environ.pop("FLASK_DEBUG", None)
         else:
             os.environ["FLASK_DEBUG"] = self._original_flask_debug
 
-    def test_web_app_mode_does_not_start_scheduler(self) -> None:
-        create_app(run_startup_tasks=False)
+    def test_factory_is_safe_by_default_even_with_scheduler_env_flags(self) -> None:
+        os.environ["SCHEDULER_ENABLED"] = "1"
+        os.environ["SCHEDULER_RUNNER"] = "1"
+
+        with patch("app._run_startup_tasks") as mock_startup:
+            create_app()
+
+        mock_startup.assert_not_called()
         self.assertFalse(scheduler_service._scheduler_initialized)
         self.assertIsNone(scheduler_service.scheduler)
+
+    def test_runtime_app_runs_bootstrap_and_can_start_scheduler(self) -> None:
+        os.environ["SCHEDULER_ENABLED"] = "1"
+
+        with patch("app._run_startup_tasks") as mock_startup:
+            with patch("app.services.scheduler_service.init_scheduler") as mock_init_scheduler:
+                create_runtime_app(start_scheduler=True)
+
+        mock_startup.assert_called_once()
+        mock_init_scheduler.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,8 @@
 import os
+
 from dotenv import load_dotenv
-from app import create_app
+
+from app import create_runtime_app
 
 load_dotenv()
 
@@ -8,7 +10,7 @@ load_dotenv()
 # Set SCHEDULER_ENABLED=1 in .env to activate
 start_scheduler = os.environ.get('SCHEDULER_ENABLED', '0') == '1'
 
-app = create_app(start_scheduler=start_scheduler)
+app = create_runtime_app(start_scheduler=start_scheduler)
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
## Summary
- split runtime bootstrap work out of the default Flask app factory
- add an explicit `create_runtime_app()` path for the web and long-running scheduler entrypoints
- update scheduler/factory regression tests and docs for the new contract

## Testing
- ./run/test.sh
- ./run/test.sh tests/test_scheduler_mode.py tests/test_scheduled_messages.py tests/test_config_security.py
- ./run/verify.sh