### PR TITLE
Reject alphabetic input when normalizing phone numbers

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -39,6 +39,10 @@ def normalize_phone(phone: object) -> str:
     raw = str(phone).strip()
     if not raw:
         return ''
+    # Reject alphabetic content (e.g. "ext", vanity numbers) so we do not
+    # accidentally merge extensions/words into a valid SMS destination.
+    if re.search(r'[A-Za-z]', raw):
+        return ''
     digits = re.sub(r'[^0-9]', '', raw)
     if not digits:
         return ''

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,10 @@ class TestNormalizePhone(unittest.TestCase):
     def test_non_numeric_input_returns_empty(self) -> None:
         self.assertEqual(normalize_phone("foo"), "")
 
+    def test_ascii_letters_in_phone_are_rejected(self) -> None:
+        self.assertEqual(normalize_phone("+1 (415) 555-2671 ext 9"), "")
+        self.assertEqual(normalize_phone("+1 415 555 FLOW"), "")
+
     def test_multiple_plus_prefixes_are_normalized(self) -> None:
         self.assertEqual(normalize_phone("++++"), "")
 


### PR DESCRIPTION
### Motivation
- Fix a bug where inputs containing alphabetic text (for example `ext` suffixes or vanity numbers) were stripped to digits and could accidentally be treated as valid SMS destinations.

### Description
- Update `normalize_phone()` to return an empty string when the raw input contains ASCII letters, preventing extension/vanity text from producing a normalized phone; add regression tests in `tests/test_utils.py` that assert extension-style and vanity inputs are rejected.

### Testing
- Bootstrapped the venv with `PYTHON_CMD=/root/.pyenv/versions/3.11.14/bin/python3.11 ./run/setup.sh` and ran the targeted unit tests with `PATH=/workspace/AOC-SMS-Admin/venv/bin:$PATH ./run/test.sh tests/test_utils.py`, which passed (`30 passed`).
- Ran static verification `PATH=/workspace/AOC-SMS-Admin/venv/bin:$PATH ./run/verify.sh` and the full test suite with `PATH=/workspace/AOC-SMS-Admin/venv/bin:$PATH ./run/test.sh`, which completed successfully (`248 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c93f2f3d108324b1720f1ffff313b1)