### PR TITLE
Provision Redis for production browser gate

### DIFF
--- a/.github/workflows/deploy-twinevia-production.yml
+++ b/.github/workflows/deploy-twinevia-production.yml
@@ -55,6 +55,11 @@ jobs:
         run: |
           ./run/test.sh -q
 
+      - name: Install isolated browser test runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes redis-server
+
       - name: Run browser regression suite
         run: |
           ./run/test_browser.sh


### PR DESCRIPTION
The production workflow correctly stopped before deployment because the clean GitHub runner did not include redis-server. This installs Redis only in the isolated validation runner so the existing browser harness can create its own ephemeral instance.\n\nValidation:\n- workflow YAML parsed successfully\n- naming audit passed\n- git diff check passed\n- full backend (719 + 7 subtests) and browser (38) suites passed locally on the release SHA