### PR TITLE
Support the first versioned production bootstrap

### DIFF
--- a/.github/workflows/deploy-twinevia-production.yml
+++ b/.github/workflows/deploy-twinevia-production.yml
@@ -303,7 +303,12 @@ jobs:
             sudo grep -q "^${key}=" "${APP_ROOT}/.env" || fail "Missing ${key} in ${APP_ROOT}/.env"
           done
 
-          sudo -u "${APP_USER}" bash -lc "set -euo pipefail; cd \"${APP_ROOT}\"; set -a; source .env; set +a; \"${ACTIVE_DBDOCTOR_BIN}\" --doctor" >/dev/null
+          DBDOCTOR_APP_ROOT="${APP_ROOT}/current"
+          if [ ! -x "${DBDOCTOR_APP_ROOT}/venv/bin/python" ]; then
+            DBDOCTOR_APP_ROOT="${APP_ROOT}"
+          fi
+          [ -x "${DBDOCTOR_APP_ROOT}/venv/bin/python" ] || fail "Python is missing from both the active release and the legacy bootstrap root."
+          sudo -u "${APP_USER}" bash -lc "set -euo pipefail; cd \"${DBDOCTOR_APP_ROOT}\"; set -a; source \"${APP_ROOT}/.env\"; set +a; TWINEVIA_SAAS_APP_ROOT=\"${DBDOCTOR_APP_ROOT}\" \"${ACTIVE_DBDOCTOR_BIN}\" --doctor" >/dev/null
 
           echo "==> Refresh deploy tooling from repo"
           sudo -u "${APP_USER}" bash -lc "cd \"${APP_ROOT}\" && git pull --ff-only"


### PR DESCRIPTION
## Root cause
The canonical database-doctor wrapper correctly defaults to `/opt/twinevia-saas/current`, but the first versioned deployment necessarily runs before that symlink exists. The preflight therefore stopped before Nginx or release promotion.

## Fix
- use the active `/current` Python whenever it exists
- fall back only during the first deployment to the validated legacy app-root Python
- fail explicitly if neither interpreter exists
- source the persistent production environment from its canonical path

## Verification
- failure reproduced in workflow run 32413569393
- workflow YAML parsed successfully
- naming and diff checks pass
- outgoing diff secret-pattern scan passes
- application and browser suites already passed in the blocked deployment run before production was touched