### PR TITLE
Make versioned release rollback boot-safe

### DIFF
--- a/deploy/deploy_twinevia_saas.sh
+++ b/deploy/deploy_twinevia_saas.sh
@@ -433,11 +433,23 @@ release_started=0
 deployment_completed=0
 cleanup_env_stage() {
   local exit_code=$?
+  local rollback_health_host
   trap - EXIT
   if [[ "${exit_code}" != "0" && "${env_installed}" == "1" && "${deployment_completed}" != "1" ]]; then
     sudo install -o root -g "${APP_GROUP}" -m 0640 "${ENV_ORIGINAL_FILE}" "${ENV_TARGET_FILE}" || true
     if [[ "${release_started}" == "1" && -L "${APP_ROOT}/current" ]]; then
       sudo systemctl restart "${SAAS_RUNTIME_UNITS[@]}" || true
+      ENV_FILE="${ENV_TARGET_FILE}"
+      rollback_health_host="$(resolve_health_host)"
+      if ! check_saas_health "${rollback_health_host}" 8; then
+        echo "==> Original configuration could not boot the rollback release; restoring the validated staged configuration." >&2
+        sudo install -o root -g "${APP_GROUP}" -m 0640 "${ENV_STAGE_FILE}" "${ENV_TARGET_FILE}" || true
+        sudo systemctl restart "${SAAS_RUNTIME_UNITS[@]}" || true
+        rollback_health_host="$(resolve_health_host)"
+        if ! check_saas_health "${rollback_health_host}" 15; then
+          echo "==> Rollback release is still unhealthy after restoring the validated staged configuration." >&2
+        fi
+      fi
     fi
   fi
   rm -f "${ENV_STAGE_FILE}" "${ENV_ORIGINAL_FILE}"

--- a/deploy/release_twinevia_saas.sh
+++ b/deploy/release_twinevia_saas.sh
@@ -102,6 +102,7 @@ create_bootstrap_release() {
     fi
     sudo cp -a "${SOURCE_ROOT}/venv" "${bootstrap_pending}/venv"
     sudo ln -s "${ENV_FILE}" "${bootstrap_pending}/.env"
+    sudo install -d -o root -g "${APP_GROUP}" -m 0550 "${bootstrap_pending}/instance"
     bootstrap_env_tmp="$(mktemp)"
     printf 'APP_RELEASE_ID=%s\nAPP_RELEASE_SHA=%s\n' "${bootstrap_id}" "${BOOTSTRAP_RELEASE_SHA}" > "${bootstrap_env_tmp}"
     sudo install -o root -g "${APP_GROUP}" -m 0440 "${bootstrap_env_tmp}" "${bootstrap_pending}/.release.env"
@@ -203,6 +204,7 @@ sudo chown "${APP_USER}:${APP_GROUP}" "${verify_cache_dir}"
 sudo -u "${APP_USER}" bash -lc "set -euo pipefail; cd \"${pending_release}\"; set -a; source \"${ENV_FILE}\"; source \"${pending_release}/.release.env\"; set +a; PYTHONPYCACHEPREFIX=\"${verify_cache_dir}\" ./run/verify.sh"
 sudo rm -rf -- "${verify_cache_dir}"
 
+sudo install -d -o root -g "${APP_GROUP}" -m 0550 "${pending_release}/instance"
 sudo chown -R root:"${APP_GROUP}" "${pending_release}"
 sudo chmod -R u=rwX,g=rX,o= "${pending_release}"
 


### PR DESCRIPTION
## Summary
- create Flask instance directories before immutable release ownership is applied
- preserve a healthy rollback by retrying the prior release with the validated staged environment if its original environment no longer boots

## Validation
- `bash -n deploy/release_twinevia_saas.sh deploy/deploy_twinevia_saas.sh`
- `./venv/bin/python -m pytest -q tests/test_platform_operations_service.py` (37 passed)
- `git diff --check`

## Production incident context
The first versioned conversion exposed both conditions: the pending release could not create `instance`, and the original environment could not boot the rollback release. Production `/health` has been restored while this durable fix proceeds through review.