### PR TITLE
Keep production worker readiness fresh

### DIFF
--- a/.github/workflows/deploy-twinevia-production.yml
+++ b/.github/workflows/deploy-twinevia-production.yml
@@ -239,37 +239,6 @@ jobs:
             printf '/opt/twinevia-saas\n'
           }
 
-          resolve_health_host() {
-            local app_base_url
-            local canonical_host
-            local trusted_hosts
-            local first_host
-
-            app_base_url="$(sudo awk -F= '$1 == "APP_BASE_URL" { value = substr($0, index($0, "=") + 1) } END { print value }' "${APP_ROOT}/.env")"
-            canonical_host="$(printf '%s' "${app_base_url}" | awk '
-              {
-                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-                gsub(/^[A-Za-z][A-Za-z0-9+.-]*:\/\//, "", $0)
-                sub(/\/.*$/, "", $0)
-                sub(/^[^@]*@/, "", $0)
-                sub(/:.*/, "", $0)
-                print $0
-              }
-            ')"
-            if [ -n "${canonical_host}" ]; then
-              printf '%s\n' "${canonical_host}"
-              return
-            fi
-
-            trusted_hosts="$(sudo grep -E '^TRUSTED_HOSTS=' "${APP_ROOT}/.env" | tail -n1 | cut -d= -f2- || true)"
-            first_host="$(printf '%s' "${trusted_hosts}" | awk -F',' '{gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1}')"
-            if [ -n "${first_host}" ]; then
-              printf '%s\n' "${first_host}"
-              return
-            fi
-            printf '127.0.0.1\n'
-          }
-
           echo "==> Production preflight"
           APP_ROOT="$(resolve_app_root)"
           APP_USER="$(resolve_app_user)"
@@ -354,7 +323,8 @@ jobs:
           sudo -u "${APP_USER}" sudo -n /usr/local/bin/restart-twinevia-saas-services --check >/dev/null
 
           echo "==> Health check"
-          HEALTH_HOST="$(resolve_health_host)"
+          HEALTH_HOST="app.twinevia.com"
+          echo "Internal health host: ${HEALTH_HOST}"
           HEALTH_RESPONSE=""
           for attempt in $(seq 1 15); do
             HEALTH_RESPONSE="$(curl -fsS --connect-timeout 2 --max-time 5 -H "Host: ${HEALTH_HOST}" http://127.0.0.1:8100/health 2>/dev/null || true)"

--- a/app/rq_worker.py
+++ b/app/rq_worker.py
@@ -10,6 +10,8 @@ from redis.exceptions import RedisError
 from rq import Queue, Worker
 from rq.worker import DequeueStrategy
 
+RQ_WORKER_TTL_SECONDS: int = 60
+
 
 def _connect_redis(redis_url: str, attempts: int) -> Redis:
     logger = logging.getLogger(__name__)
@@ -53,7 +55,12 @@ def main() -> None:
     resolved_worker_name = worker_name or f"twinevia-{socket.gethostname()}-{os.getpid()}"
     connection = _connect_redis(redis_url, 3)
     queue = Queue(queue_name, connection=connection)
-    worker = Worker([queue], name=resolved_worker_name, connection=connection)
+    worker = Worker(
+        [queue],
+        name=resolved_worker_name,
+        connection=connection,
+        default_worker_ttl=RQ_WORKER_TTL_SECONDS,
+    )
     worker.work(
         burst=False,
         logging_level="INFO",


### PR DESCRIPTION
Production gate fix:

- shorten the RQ idle dequeue cycle so its heartbeat remains within the existing 120-second readiness window
- use the canonical app host directly in the production-only internal health assertion
- preserve retry-based internal and external health/readiness verification

Validated locally:
- 719 tests and 7 subtests passed
- 42 targeted readiness/operations tests passed
- isolated Redis/RQ readiness harness passed
- naming audit, workflow YAML, embedded remote shell syntax, and diff checks passed