### PR TITLE
Read release attestation through deployment sudo

### DIFF
--- a/.github/workflows/deploy-twinevia-production.yml
+++ b/.github/workflows/deploy-twinevia-production.yml
@@ -346,7 +346,7 @@ jobs:
             sleep 2
           done
           [ "${READY_RESPONSE}" = "READY" ] || fail "Readiness endpoint did not return READY after 15 attempts."
-          CURRENT_RELEASE="$(readlink -f "${APP_ROOT}/current")"
+          CURRENT_RELEASE="$(sudo readlink -f "${APP_ROOT}/current")"
           RELEASE_SHA="$(sudo awk -F= '$1 == "APP_RELEASE_SHA" { print substr($0, index($0, "=") + 1) }' "${CURRENT_RELEASE}/.release.env")"
           [ "${RELEASE_SHA}" = "${EXPECTED_SHA}" ] || fail "Active release ${RELEASE_SHA} does not match workflow commit ${EXPECTED_SHA}."
 


### PR DESCRIPTION
The release is active and healthy, but the production workflow could not resolve the hardened `current` target as the unprivileged SSH user. Use the existing deployment sudo boundary for the read-only release attestation.

Validated:
- exact command succeeds against the active production release and matches `5f2eb808c62e3cb381e060a44dc2543ea068efe3`
- workflow YAML and embedded remote shell syntax pass
- 42 readiness/operations tests pass
- naming audit passes