### PR TITLE
Polish marketing hero boundaries

### DIFF
--- a/app/static/css/marketing.css
+++ b/app/static/css/marketing.css
@@ -349,7 +349,7 @@ main:focus {
   grid-template-rows: auto 1fr auto;
   align-self: stretch;
   min-width: 0;
-  margin-block: 1rem;
+  margin-block: 0;
   background: var(--paper);
   color: var(--ink);
   box-shadow: 0 8px 22px rgba(0, 10, 27, 0.14);
@@ -642,7 +642,7 @@ main:focus {
   align-self: stretch;
   min-width: 0;
   flex-direction: column;
-  margin: 1rem 0;
+  margin: 0;
   padding: clamp(3.25rem, 4.4vw, 4.25rem) clamp(1.6rem, 2.6vw, 2.5rem) 2rem;
   background: var(--paper);
   box-shadow: inset 1px 0 0 var(--rule);
@@ -712,7 +712,7 @@ main:focus {
 .reply-thread__response::after {
   content: "";
   position: absolute;
-  right: calc(100% + var(--reply-connector-run) - 4px);
+  right: calc(100% + var(--reply-connector-run) - 5px);
   bottom: calc(50% + var(--reply-connector-rise) - 4px);
   width: 8px;
   height: 8px;
@@ -2017,6 +2017,62 @@ main:focus {
 }
 
 @media (max-width: 1180px) {
+  .site-header {
+    grid-template-columns: 1fr auto;
+  }
+
+  .desktop-nav,
+  .desktop-actions {
+    display: none;
+  }
+
+  .mobile-menu {
+    position: relative;
+    display: block;
+  }
+
+  .mobile-menu summary {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.7rem;
+    cursor: pointer;
+    font-size: 0.82rem;
+    font-weight: 800;
+    list-style: none;
+  }
+
+  .mobile-menu summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .mobile-menu nav {
+    position: absolute;
+    z-index: 20;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    display: grid;
+    width: min(290px, calc(100vw - 2.5rem));
+    padding: 0.75rem;
+    border: 1px solid #29466d;
+    background: var(--navy);
+    box-shadow: 0 18px 38px rgba(0, 10, 27, 0.32);
+  }
+
+  .mobile-menu nav > a:not(.button) {
+    padding: 0.72rem;
+    color: #dce7f7;
+    font-size: 0.85rem;
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  .mobile-menu .button {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+
   .dispatch-hero {
     grid-template-columns: minmax(250px, 0.75fr) minmax(470px, 1.35fr);
   }
@@ -2078,62 +2134,6 @@ main:focus {
 }
 
 @media (max-width: 960px) {
-  .site-header {
-    grid-template-columns: 1fr auto;
-  }
-
-  .desktop-nav,
-  .desktop-actions {
-    display: none;
-  }
-
-  .mobile-menu {
-    position: relative;
-    display: block;
-  }
-
-  .mobile-menu summary {
-    display: inline-flex;
-    min-height: 44px;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.55rem 0.7rem;
-    cursor: pointer;
-    font-size: 0.82rem;
-    font-weight: 800;
-    list-style: none;
-  }
-
-  .mobile-menu summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .mobile-menu nav {
-    position: absolute;
-    z-index: 20;
-    top: calc(100% + 0.5rem);
-    right: 0;
-    display: grid;
-    width: min(290px, calc(100vw - 2.5rem));
-    padding: 0.75rem;
-    border: 1px solid #29466d;
-    background: var(--navy);
-    box-shadow: 0 18px 38px rgba(0, 10, 27, 0.32);
-  }
-
-  .mobile-menu nav > a:not(.button) {
-    padding: 0.72rem;
-    color: #dce7f7;
-    font-size: 0.85rem;
-    font-weight: 750;
-    text-decoration: none;
-  }
-
-  .mobile-menu .button {
-    width: 100%;
-    margin-top: 0.5rem;
-  }
-
   .dispatch-hero {
     grid-template-columns: 1fr;
   }

--- a/tests/browser/public-marketing-layout.spec.js
+++ b/tests/browser/public-marketing-layout.spec.js
@@ -58,9 +58,27 @@ async function layoutMetrics(page) {
     const attempts = document.querySelector('.attempts-region');
     const footer = document.querySelector('.site-footer');
     const identity = rect('.dispatch-promise__identity');
+    const docketPanel = rect('.dispatch-docket');
     const replyPanel = rect('.reply-margin');
     const replyResponse = rect('.reply-thread__response');
     const replyResponseIcon = rect('.reply-thread__response i');
+    const replyConnector = getComputedStyle(
+      document.querySelector('.reply-thread__response'),
+      '::before'
+    );
+    const replyConnectorDot = getComputedStyle(
+      document.querySelector('.reply-thread__response'),
+      '::after'
+    );
+    const replyConnectorLineCenter = (
+      -Number.parseFloat(replyConnector.right)
+      - Number.parseFloat(replyConnector.width)
+      + (Number.parseFloat(replyConnector.borderLeftWidth) / 2)
+    );
+    const replyConnectorDotCenter = (
+      -Number.parseFloat(replyConnectorDot.right)
+      - (Number.parseFloat(replyConnectorDot.width) / 2)
+    );
     const replyItems = Array.from(document.querySelectorAll('.reply-thread span, .reply-thread time')).map((element) => {
       const bounds = textBounds(element);
       const style = getComputedStyle(element);
@@ -78,6 +96,8 @@ async function layoutMetrics(page) {
       documentScrollWidth: document.documentElement.scrollWidth,
       footerBottom: footer.getBoundingClientRect().bottom + window.scrollY,
       footerHeight: footer.getBoundingClientRect().height,
+      desktopActionsDisplay: getComputedStyle(document.querySelector('.desktop-actions')).display,
+      desktopActions: rect('.desktop-actions'),
       headerBackground: getComputedStyle(document.querySelector('.site-header')).backgroundColor,
       header: rect('.site-header'),
       hero: rect('.dispatch-hero'),
@@ -107,10 +127,16 @@ async function layoutMetrics(page) {
         };
       }),
       promise,
+      docketPanel,
+      mobileMenuDisplay: getComputedStyle(document.querySelector('.mobile-menu')).display,
+      mobileMenuSummary: rect('.mobile-menu summary'),
       replyConnectorDisplay: getComputedStyle(
         document.querySelector('.reply-thread__response'),
         '::before'
       ).display,
+      replyConnectorCenterError: Math.abs(
+        replyConnectorLineCenter - replyConnectorDotCenter
+      ),
       replyIconClearance: replyResponseIcon.left - replyResponse.left,
       replyItems,
       replyPanel,
@@ -139,6 +165,7 @@ test('home geometry remains intact across the responsive breakpoint seams', asyn
     { width: 1180, height: 900 },
     { width: 1181, height: 900 },
     { width: 1200, height: 900 },
+    { width: 1226, height: 900 },
     { width: 1600, height: 1000 },
   ];
 
@@ -161,6 +188,23 @@ test('home geometry remains intact across the responsive breakpoint seams', asyn
     expect(metrics.replyIconClearance).toBeGreaterThanOrEqual(8);
     expect(metrics.identity.left).toBeGreaterThanOrEqual(metrics.promise.left - 1);
     expect(metrics.identity.right).toBeLessThanOrEqual(metrics.promise.right + 1);
+
+    if (viewport.width <= 1180) {
+      expect(metrics.desktopActionsDisplay).toBe('none');
+      expect(metrics.mobileMenuDisplay).not.toBe('none');
+      expect(metrics.mobileMenuSummary.left).toBeGreaterThanOrEqual(metrics.header.left - 1);
+      expect(metrics.mobileMenuSummary.right).toBeLessThanOrEqual(metrics.header.right + 1);
+    } else {
+      expect(metrics.desktopActionsDisplay).not.toBe('none');
+      expect(metrics.mobileMenuDisplay).toBe('none');
+      expect(metrics.desktopActions.left).toBeGreaterThanOrEqual(metrics.header.left - 1);
+      expect(metrics.desktopActions.right).toBeLessThanOrEqual(metrics.header.right + 1);
+      expect(Math.abs(metrics.docketPanel.top - metrics.hero.top)).toBeLessThanOrEqual(1);
+      expect(Math.abs(metrics.docketPanel.bottom - metrics.hero.bottom)).toBeLessThanOrEqual(1);
+      expect(Math.abs(metrics.replyPanel.top - metrics.hero.top)).toBeLessThanOrEqual(1);
+      expect(Math.abs(metrics.replyPanel.bottom - metrics.hero.bottom)).toBeLessThanOrEqual(1);
+      expect(metrics.replyConnectorCenterError).toBeLessThanOrEqual(0.1);
+    }
 
     for (const term of metrics.offerTerms) {
       expect(term.descriptionTop).toBeGreaterThanOrEqual(term.metricBottom - 1);


### PR DESCRIPTION
## Summary
- remove the staggered white-panel margins that created the top-right and lower hero notches
- switch the header to its compact menu before intermediate-width actions can crowd or crop
- center the red connector stroke on its endpoint dot
- lock the 1226px Mac layout, breakpoint behavior, panel seams, and connector geometry into browser regression coverage

## Validation
- ./run/verify.sh
- ./run/test_browser.sh tests/browser/public-marketing-layout.spec.js (4 passed)
- ./run/test_browser.sh (38 passed)
- visual QA in the real Mac Chrome window at the reported width