### PR TITLE
Fix production monitor repository context

### DIFF
--- a/.github/workflows/monitor-twinevia-production.yml
+++ b/.github/workflows/monitor-twinevia-production.yml
@@ -50,6 +50,7 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           JOB_STATUS: ${{ job.status }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- provide the GitHub repository explicitly to the no-checkout incident-update step
- allow successful monitor runs to query, update, and close uptime incidents

## Validation
- reproduced the existing `fatal: not a git repository` failure from run 32445146760
- parsed the workflow YAML successfully
- verified `gh issue list` succeeds with `GH_REPO=magasiev13/AOC-SMS-Admin`
- `git diff --check`